### PR TITLE
Reduce frequency of reconcilliation

### DIFF
--- a/watches.yaml
+++ b/watches.yaml
@@ -3,4 +3,5 @@
   group: migration.openshift.io
   kind: MigrationController
   role: /opt/ansible/roles/migrationcontroller
+  reconcilePeriod: 30m
   manageStatus: False


### PR DESCRIPTION
We're constantly burning up a lot of CPU reconciling when there are no changes.

Every time we reconcile we consume up to ~0.5-0.6 CPU. The default reconciliation period is 1m. Reconciling every minute means we're almost always using up half a core as we're almost never idle. This PR changes the period to 30m.

If a MigrationController CR is modified it still triggers an immediate reconcilliation.