### PR TITLE
Rename velero clusterrolebinding to avoid conflict with existing install

### DIFF
--- a/roles/migrationcontroller/templates/velero_supporting.yml.j2
+++ b/roles/migrationcontroller/templates/velero_supporting.yml.j2
@@ -164,7 +164,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: velero
+  name: migration-velero
   labels:
     component: velero
 subjects:


### PR DESCRIPTION
If an existing velero install already exists in the velero namespace,
konveyor install will break the existing velero by overwriting the
velero (cluster-scoped) cluster role binding. This commit uses a different
name to avoid the conflict.

For each of the following check the box when you have verified either:
* the changes have been made for each applicable version
* no changes are required for the item

Affected versions: (all versions affected, but there's only one copy of the velero yaml, as it's not versioned)
* [x ] Latest
* [x ] 1.1
* [x ] 1.0

The CSV is responsible in OLM installs for
no CSV changes
* [ ] Operator permissions
* [ ] Operator deployment
* [ ] Operand permissions
* [ ] CRDs

The operator.yml is responsible in non-OLM installs for
no operatory.yml changes
* [ ] Operator permissions
* [ ] Operator deployment

The ansible role is responsible in non-OLM installs for:
no ansible role changes
* [ ] Operand permissions
* [ ] CRDs

The ansible role is always responsible for:
* [ ] Operand deployment

If this PR updates a release or replaces channel 
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] Updated the `.github/pull_request_template.md` Affected versions list
