### PR TITLE
Use watch namespace as default ns

### DIFF
--- a/roles/migrationcontroller/defaults/main.yml
+++ b/roles/migrationcontroller/defaults/main.yml
@@ -16,7 +16,7 @@ discovery_volume_path: "/var/cache/discovery"
 mig_pv_limit: "100"
 mig_pod_limit: "100"
 mig_namespace_limit: "10"
-mig_namespace: openshift-migration
+mig_namespace: "{{ lookup( 'env', 'WATCH_NAMESPACE') | default('openshift-migration') }}"
 mig_svc_account: true
 mig_ui_cluster_api_endpoint: ""
 mig_ui_configmap_data: ""


### PR DESCRIPTION
For each of the following check the box when you have verified either:
* the changes have been made for each applicable version
* no changes are required for the item

Affected versions:
* [x] Latest
* [ ] 1.1
* [ ] 1.0

The CSV is responsible in OLM installs for
* [x] Operator permissions
* [x] Operator deployment
* [x] Operand permissions
* [x] CRDs

The operator.yml is responsible in non-OLM installs for
* [x] Operator permissions
* [x] Operator deployment

The ansible role is responsible in non-OLM installs for:
* [x] Operand permissions
* [x] CRDs

The ansible role is always responsible for:
* [x] Operand deployment

If this PR updates a release or replaces channel 
* [x] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [x] I updated channels in the `konveyor-operator.package.yaml`
* [x] I created a new release directory in `deploy/non-olm`
* [x] I created or updated the major.minor link in `deploy/non-olm`
* [x] Updated the `.github/pull_request_template.md` Affected versions list
