### PR TITLE
Always install crds for nonolm

### DIFF
--- a/roles/migrationcontroller/tasks/main.yml
+++ b/roles/migrationcontroller/tasks/main.yml
@@ -149,19 +149,19 @@
       state: "{{ velero_state }}"
       definition: "{{ lookup('template', 'velero.yml.j2') }}"
 
+  - name: "Set up migration CRDs"
+    k8s:
+      state: "present"
+      src: "{{ role_path }}/files/{{ item }}"
+    with_items:
+      - "migration_v1alpha1_migcluster.yaml"
+      - "migration_v1alpha1_migmigration.yaml"
+      - "migration_v1alpha1_migplan.yaml"
+      - "migration_v1alpha1_migstorage.yaml"
+    when: not olm_managed
+
   - when: migration_controller or migration_ui
     block:
-    - name: "Set up migration CRDs"
-      k8s:
-        state: "present"
-        src: "{{ role_path }}/files/{{ item }}"
-      with_items:
-        - "migration_v1alpha1_migcluster.yaml"
-        - "migration_v1alpha1_migmigration.yaml"
-        - "migration_v1alpha1_migplan.yaml"
-        - "migration_v1alpha1_migstorage.yaml"
-      when: not olm_managed
-
     - name: "Set up mig controller RBAC"
       k8s:
         state: "{{ controller_state }}"


### PR DESCRIPTION
For each of the following check the box when you have verified either:
* the changes have been made for each applicable version
* no changes are required for the item

Affected versions:
* [x] Latest
* [x] 1.1
* [ ] 1.0

The CSV is responsible in OLM installs for
* [x] Operator permissions
* [x] Operator deployment
* [x] Operand permissions
* [x] CRDs

The operator.yml is responsible in non-OLM installs for
* [x] Operator permissions
* [x] Operator deployment

The ansible role is responsible in non-OLM installs for:
* [x] Operand permissions
* [x] CRDs

The ansible role is always responsible for:
* [x] Operand deployment

If this PR updates a release or replaces channel 
* [x] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [x] I updated channels in the `konveyor-operator.package.yaml`
* [x] I created a new release directory in `deploy/non-olm`
* [x] I created or updated the major.minor link in `deploy/non-olm`
* [x] Updated the `.github/pull_request_template.md` Affected versions list
