### PR TITLE
Remove verbs OLM doesn't understand

### DIFF
--- a/deploy/olm-catalog/konveyor-operator/v1.2.0/konveyor-operator.v1.2.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/konveyor-operator/v1.2.0/konveyor-operator.v1.2.0.clusterserviceversion.yaml
@@ -710,7 +710,6 @@ spec:
           - delete
           - assign
           - deletecollection
-          - edit
         - nonResourceURLs:
           - '*'
           verbs:

--- a/deploy/olm-catalog/konveyor-operator/v1.2.0/konveyor-operator.v1.2.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/konveyor-operator/v1.2.0/konveyor-operator.v1.2.0.clusterserviceversion.yaml
@@ -677,10 +677,17 @@ spec:
       - serviceAccountName: velero
         rules:
         - apiGroups:
+          - build.openshift.io
           - migration.openshift.io
           - velero.io
           resources:
           - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
           verbs:
           - '*'
         - apiGroups:
@@ -702,9 +709,6 @@ spec:
           - create
           - delete
           - assign
-          - view
-          - admin
-          - impersonate
           - deletecollection
           - edit
         - nonResourceURLs:

--- a/roles/migrationcontroller/templates/velero_supporting.yml.j2
+++ b/roles/migrationcontroller/templates/velero_supporting.yml.j2
@@ -200,7 +200,6 @@ rules:
   - delete
   - assign
   - deletecollection
-  - edit
 - nonResourceURLs:
   - '*'
   verbs:

--- a/roles/migrationcontroller/templates/velero_supporting.yml.j2
+++ b/roles/migrationcontroller/templates/velero_supporting.yml.j2
@@ -167,10 +167,17 @@ metadata:
   name: migration-velero
 rules:
 - apiGroups:
+  - build.openshift.io
   - migration.openshift.io
   - velero.io
   resources:
   - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
   verbs:
   - '*'
 - apiGroups:
@@ -192,9 +199,6 @@ rules:
   - create
   - delete
   - assign
-  - view
-  - admin
-  - impersonate
   - deletecollection
   - edit
 - nonResourceURLs:


### PR DESCRIPTION
It appears OLM doesn't have the full list of verbs we need:

```
failed: error creating csv konveyor-operator.v1.2.0: ClusterServiceVersion.operators.coreos.com "konveyor-operator.v1.2.0" is invalid: [: Invalid value: "": "spec.install" must validate one and only one schema (oneOf). Found none valid, spec.install.spec.clusterPermissions.rules.verbs: Unsupported value: "admin": supported values: "*", "assign", "get", "list", "watch", "create", "update", "patch", "put", "post", "delete", "deletecollection", "initialize", "use"]
```
But these definitely exist:
```
APIGroups:["build.openshift.io"], Resources:["jenkins"], Verbs:["edit" "view" "view" "admin" "edit" "view"]}                                                                                                     
{APIGroups:[""], Resources:["serviceaccounts"], Verbs:["deletecollection" "impersonate" "deletecollection"]}
```
This PR works around the problem by using `'*'` for these select apigroups/resources, which OLM does accept as a value for verbs.

For each of the following check the box when you have verified either:
* the changes have been made for each applicable version
* no changes are required for the item

Affected versions:
* [x] Latest
* [ ] 1.1
* [ ] 1.0

The CSV is responsible in OLM installs for
* [x] Operator permissions
* [x] Operator deployment
* [x] Operand permissions
* [x] CRDs

The operator.yml is responsible in non-OLM installs for
* [x] Operator permissions
* [x] Operator deployment

The ansible role is responsible in non-OLM installs for:
* [x] Operand permissions
* [x] CRDs

The ansible role is always responsible for:
* [x] Operand deployment

If this PR updates a release or replaces channel 
* [x] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [x] I updated channels in the `konveyor-operator.package.yaml`
* [x] I created a new release directory in `deploy/non-olm`
* [x] I created or updated the major.minor link in `deploy/non-olm`
* [x] Updated the `.github/pull_request_template.md` Affected versions list
