### PR TITLE
Updated CRDs to include  field

### DIFF
--- a/deploy/olm-catalog/konveyor-operator/v1.2.0/migmigration.crd.yaml
+++ b/deploy/olm-catalog/konveyor-operator/v1.2.0/migmigration.crd.yaml
@@ -28,6 +28,8 @@ spec:
           type: object
         spec:
           properties:
+            canceled:
+              type: boolean
             keepAnnotations:
               type: boolean
             migPlanRef:

--- a/roles/migrationcontroller/files/migration_v1alpha1_migmigration.yaml
+++ b/roles/migrationcontroller/files/migration_v1alpha1_migmigration.yaml
@@ -28,6 +28,8 @@ spec:
           type: object
         spec:
           properties:
+            canceled:
+              type: boolean
             keepAnnotations:
               type: boolean
             migPlanRef:


### PR DESCRIPTION
For each of the following check the box when you have verified either:
* the changes have been made for each applicable version
* no changes are required for the item

Affected versions:
* [x] Latest
* [ ] 1.1
* [ ] 1.0

The CSV is responsible in OLM installs for
* [x] Operator permissions
* [x] Operator deployment
* [x] Operand permissions
* [x] CRDs

The operator.yml is responsible in non-OLM installs for
* [x] Operator permissions
* [x] Operator deployment

The ansible role is responsible in non-OLM installs for:
* [x] Operand permissions
* [x] CRDs

The ansible role is always responsible for:
* [x] Operand deployment

If this PR updates a release or replaces channel 
* [x] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [x] I updated channels in the `konveyor-operator.package.yaml`
* [x] I created a new release directory in `deploy/non-olm`
* [x] I created or updated the major.minor link in `deploy/non-olm`
* [x] Updated the `.github/pull_request_template.md` Affected versions list

Part of https://github.com/konveyor/mig-controller/pull/452, should be merged simultaneously 