### PR TITLE
Add rbac to wildcard verb group for velero SA

### DIFF
--- a/deploy/olm-catalog/konveyor-operator/v1.2.0/konveyor-operator.v1.2.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/konveyor-operator/v1.2.0/konveyor-operator.v1.2.0.clusterserviceversion.yaml
@@ -679,6 +679,7 @@ spec:
         - apiGroups:
           - build.openshift.io
           - migration.openshift.io
+          - rbac.authorization.k8s.io
           - velero.io
           resources:
           - '*'

--- a/roles/migrationcontroller/templates/velero_supporting.yml.j2
+++ b/roles/migrationcontroller/templates/velero_supporting.yml.j2
@@ -169,6 +169,7 @@ rules:
 - apiGroups:
   - build.openshift.io
   - migration.openshift.io
+  - rbac.authorization.k8s.io
   - velero.io
   resources:
   - '*'


### PR DESCRIPTION
Velero needs admin for RBAC. This is one of the verbs OLM doesn't recognize:
https://bugzilla.redhat.com/show_bug.cgi?id=1814701
https://github.com/konveyor/mig-operator/pull/264

For each of the following check the box when you have verified either:
* the changes have been made for each applicable version
* no changes are required for the item

Affected versions:
* [X] Latest
* [ ] 1.1
* [ ] 1.0

The CSV is responsible in OLM installs for
* [x] Operator permissions
* [x] Operator deployment
* [x] Operand permissions
* [x] CRDs

The operator.yml is responsible in non-OLM installs for
* [X] Operator permissions
* [x] Operator deployment

The ansible role is responsible in non-OLM installs for:
* [x] Operand permissions
* [x] CRDs

The ansible role is always responsible for:
* [x] Operand deployment

If this PR updates a release or replaces channel 
* [x] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [x] I updated channels in the `konveyor-operator.package.yaml`
* [x] I created a new release directory in `deploy/non-olm`
* [x] I created or updated the major.minor link in `deploy/non-olm`
* [x] Updated the `.github/pull_request_template.md` Affected versions list
