### PR TITLE
Use ansible-operator-latest

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,7 +1,10 @@
 FROM quay.io/operator-framework/ansible-operator:latest
 
 USER root
-RUN yum -y update && yum -y install python3-boto3 && yum clean all
+RUN yum -y update \
+ && yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
+ && yum -y install python3-boto3 \
+ && yum clean all
 USER 1001
 COPY watches.yaml ${HOME}/watches.yaml
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,7 +1,7 @@
 FROM quay.io/operator-framework/ansible-operator:latest
 
 USER root
-RUN yum -y update && yum -y install python-boto3 && yum clean all
+RUN yum -y update && yum -y install python3-boto3 && yum clean all
 USER 1001
 COPY watches.yaml ${HOME}/watches.yaml
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/ansible-operator:v0.9.0
+FROM quay.io/operator-framework/ansible-operator:latest
 
 USER root
 RUN yum -y update && yum -y install python-boto3 && yum clean all

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -10,6 +10,10 @@ RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.n
  && yum -y install python3-boto3 \
  && yum clean all
 USER 1001
+COPY build/requirements.yml ${HOME}/requirements.yml
+RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \
+ && chmod -R ug+rwx ${HOME}/.ansible
+
 COPY watches.yaml ${HOME}/watches.yaml
 
 COPY roles/ ${HOME}/roles/

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,8 +1,12 @@
 FROM quay.io/operator-framework/ansible-operator:latest
 
 USER root
-RUN yum -y update \
- && yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
+
+RUN yum -y update && yum clean all
+
+RUN echo -ne "[centos-8-appstream]\nname = CentOS 8 (RPMs) - AppStream\nbaseurl = http://mirror.centos.org/centos-8/8/AppStream/x86_64/os/\nenabled = 1\ngpgcheck = 0" > /etc/yum.repos.d/centos.repo
+
+RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
  && yum -y install python3-boto3 \
  && yum clean all
 USER 1001

--- a/build/requirements.yml
+++ b/build/requirements.yml
@@ -1,0 +1,3 @@
+collections:
+  - community.kubernetes
+  - operator_sdk.util

--- a/roles/migrationcontroller/tasks/main.yml
+++ b/roles/migrationcontroller/tasks/main.yml
@@ -10,7 +10,7 @@
         definition: "{{ lookup('template', 'migration-controller.yml.j2') }}"
 
     - name: Clean conditions and set Reconciling state
-      k8s_status:
+      operator_sdk.util.k8s_status:
         api_version: migration.openshift.io/v1alpha1
         kind: MigrationController
         name: "{{ meta.name }}"
@@ -325,7 +325,7 @@
             definition: "{{ lookup('file', '/tmp/kubeapiserver.yaml') | from_yaml }}"
 
       - name: Assert kubeapiserver setup matches the deprecated_cors_configuration setting
-        k8s_status:
+        operator_sdk.util.k8s_status:
           api_version: migration.openshift.io/v1alpha1
           kind: MigrationController
           name: "{{ meta.name }}"
@@ -341,7 +341,7 @@
               mig_ui_cors_url in apiserver.resources[0].spec.additionalCORSAllowedOrigins
 
       - name: Assert apiserver setup matches the deprecated_cors_configuration setting
-        k8s_status:
+        operator_sdk.util.k8s_status:
           api_version: migration.openshift.io/v1alpha1
           kind: MigrationController
           name: "{{ meta.name }}"
@@ -524,7 +524,7 @@
       reconciled: true
 
   always:
-  - k8s_status:
+  - operator_sdk.util.k8s_status:
       api_version: migration.openshift.io/v1alpha1
       kind: MigrationController
       name: "{{ meta.name }}"
@@ -533,7 +533,7 @@
         phase: Reconciled
     when: olm_managed and reconciled
 
-  - k8s_status:
+  - operator_sdk.util.k8s_status:
       api_version: migration.openshift.io/v1alpha1
       kind: MigrationController
       name: "{{ meta.name }}"
@@ -553,7 +553,7 @@
           controller.resources is defined and
           controller.resources[0].status.conditions is defined
     block:
-    - k8s_status:
+    - operator_sdk.util.k8s_status:
         api_version: migration.openshift.io/v1alpha1
         kind: MigrationController
         name: "{{ meta.name }}"


### PR DESCRIPTION
Someone needs to build and do a sanity test before we do this.
Fixes #271

For each of the following check the box when you have verified either:
* the changes have been made for each applicable version
* no changes are required for the item

Affected versions:
* [X] Latest
* [ ] 1.1
* [ ] 1.0

The CSV is responsible in OLM installs for
* [x] Operator permissions
* [x] Operator deployment
* [x] Operand permissions
* [x] CRDs

The operator.yml is responsible in non-OLM installs for
* [x] Operator permissions
* [x] Operator deployment

The ansible role is responsible in non-OLM installs for:
* [x] Operand permissions
* [x] CRDs

The ansible role is always responsible for:
* [x] Operand deployment

If this PR updates a release or replaces channel 
* [x] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [x] I updated channels in the `konveyor-operator.package.yaml`
* [x] I created a new release directory in `deploy/non-olm`
* [x] I created or updated the major.minor link in `deploy/non-olm`
* [x] Updated the `.github/pull_request_template.md` Affected versions list
