### PR TITLE
Recreate resources when we can't patch them

### DIFF
--- a/roles/migrationcontroller/tasks/main.yml
+++ b/roles/migrationcontroller/tasks/main.yml
@@ -386,10 +386,21 @@
             state: present
             definition: "{{ lookup('file', '/tmp/authentication.yaml') | from_yaml }}"
 
-  - name: "Set up mig controller"
-    k8s:
-      state: "{{ controller_state }}"
-      definition: "{{ lookup('template', 'controller.yml.j2') }}"
+  - block:
+    - name: "Set up mig controller"
+      k8s:
+        state: "{{ controller_state }}"
+        definition: "{{ lookup('template', 'controller.yml.j2') }}"
+    rescue:
+    - name: "Set up mig controller"
+      k8s:
+        state: absent
+        definition: "{{ lookup('template', 'controller.yml.j2') }}"
+
+    - name: "Set up mig controller"
+      k8s:
+        state: "{{ controller_state }}"
+        definition: "{{ lookup('template', 'controller.yml.j2') }}"
 
   - name: Check if discovery route exists
     k8s_facts:
@@ -439,10 +450,21 @@
           definition: "{{ lookup('template', 'ui.yml.j2') }}"
         when: not(configmap_secret == mig_ui_oauth_secret) and not skip_ui_restart
 
-  - name: "Set up mig ui"
-    k8s:
-      state: "{{ ui_state }}"
-      definition: "{{ lookup('template', 'ui.yml.j2') }}"
+  - block:
+    - name: "Set up mig ui"
+      k8s:
+        state: "{{ ui_state }}"
+        definition: "{{ lookup('template', 'ui.yml.j2') }}"
+    rescue:
+    - name: "Set up mig ui"
+      k8s:
+        state: absent
+        definition: "{{ lookup('template', 'ui.yml.j2') }}"
+
+    - name: "Set up mig ui"
+      k8s:
+        state: "{{ ui_state }}"
+        definition: "{{ lookup('template', 'ui.yml.j2') }}"
 
   - when: migration_controller or migration_ui
     name: "Set up host MigCluster"


### PR DESCRIPTION
This needs to be CP'd to release-1.1 to fix upgrades in 1.1.2. Sergio should be filing a BZ

Affected versions:
* [X] Latest
* [X] 1.1
* [ ] 1.0

The CSV is responsible in OLM installs for
* [X] Operator permissions
* [X] Operator deployment
* [X] Operand permissions
* [X] CRDs

The operator.yml is responsible in non-OLM installs for
* [X] Operator permissions
* [X] Operator deployment

The ansible role is responsible in non-OLM installs for:
* [X] Operand permissions
* [X] CRDs

The ansible role is always responsible for:
* [x] Operand deployment

If this PR updates a release or replaces channel 
* [X] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [X] I updated channels in the `konveyor-operator.package.yaml`
* [X] I created a new release directory in `deploy/non-olm`
* [X] I created or updated the major.minor link in `deploy/non-olm`
* [X] Updated the `.github/pull_request_template.md` Affected versions list
