### PR TITLE
Update konveyor 1.1.2 CSV to match downstream

### DIFF
--- a/deploy/olm-catalog/konveyor-operator/v1.1.2/konveyor-operator.v1.1.2.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/konveyor-operator/v1.1.2/konveyor-operator.v1.1.2.clusterserviceversion.yaml
@@ -295,17 +295,10 @@ spec:
           - '*'
         - apiGroups:
           - apps
-          resources:
-          - deployments
-          - daemonsets
-          - replicasets
-          - statefulsets
-          verbs:
-          - '*'
-        - apiGroups:
+          - batch
           - extensions
           resources:
-          - daemonsets
+          - '*'
           verbs:
           - '*'
         - apiGroups:


### PR DESCRIPTION
For each of the following check the box when you have verified either:
* the changes have been made for each applicable version
* no changes are required for the item

Affected versions:
* [ ] Latest
* [x] 1.1
* [ ] 1.0

The CSV is responsible in OLM installs for
* [ ] Operator permissions
* [ ] Operator deployment
* [ ] Operand permissions
* [ ] CRDs

The operator.yml is responsible in non-OLM installs for
* [ ] Operator permissions
* [ ] Operator deployment

The ansible role is responsible in non-OLM installs for:
* [ ] Operand permissions
* [ ] CRDs

The ansible role is always responsible for:
* [ ] Operand deployment

If this PR updates a release or replaces channel 
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] Updated the `.github/pull_request_template.md` Affected versions list
