### PR TITLE
Add proxy env vars to pods

### DIFF
--- a/roles/migrationcontroller/defaults/main.yml
+++ b/roles/migrationcontroller/defaults/main.yml
@@ -4,6 +4,8 @@ configmap_secret: ""
 controller_state: absent
 deprecated_cors_configuration: false
 cors_origins: []
+http_proxy: "{{ lookup( 'env', 'HTTP_PROXY') }}"
+https_proxy: "{{ lookup( 'env', 'HTTPS_PROXY') }}"
 image_pull_policy: Always
 mig_controller_image: "{{ registry }}/{{ project }}/{{ mig_controller_repo }}"
 mig_controller_limits_cpu: "100m"
@@ -33,6 +35,7 @@ migration_registry_image: "{{ registry }}/{{ project }}/{{ migration_registry_re
 migration_registry_repo: "{{ lookup( 'env', 'MIGRATION_REGISTRY_REPO') }}"
 migration_registry_version: "{{ lookup( 'env', 'MIGRATION_REGISTRY_TAG') }}"
 migration_registry_image_fqin: "{{ migration_registry_image }}:{{ migration_registry_version }}"
+no_proxy: "{{ lookup( 'env', 'NO_PROXY') }}"
 olm_managed: false
 registry: "{{ lookup( 'env', 'REGISTRY') }}"
 project: "{{ lookup( 'env', 'PROJECT') }}"

--- a/roles/migrationcontroller/templates/controller.yml.j2
+++ b/roles/migrationcontroller/templates/controller.yml.j2
@@ -82,6 +82,18 @@ spec:
           value: webhook-server-secret
         - name: MIGRATION_REGISTRY_IMAGE
           value: {{ migration_registry_image_fqin }}
+{% if http_proxy|length >0 %}
+        - name: HTTP_PROXY
+          value: {{ http_proxy }}
+{% endif %}
+{% if https_proxy|length >0 %}
+        - name: HTTPS_PROXY
+          value: {{ https_proxy }}
+{% endif %}
+{% if no_proxy|length >0 %}
+        - name: NO_PROXY
+          value: {{ no_proxy }}
+{% endif %}
         envFrom:
         - configMapRef:
             name: migration-controller
@@ -114,6 +126,18 @@ spec:
           value: discovery
         - name: SECRET_NAME
           value: webhook-server-secret
+{% if http_proxy|length >0 %}
+        - name: HTTP_PROXY
+          value: {{ http_proxy }}
+{% endif %}
+{% if https_proxy|length >0 %}
+        - name: HTTPS_PROXY
+          value: {{ https_proxy }}
+{% endif %}
+{% if no_proxy|length >0 %}
+        - name: NO_PROXY
+          value: {{ no_proxy }}
+{% endif %}
         envFrom:
         - configMapRef:
             name: migration-controller

--- a/roles/migrationcontroller/templates/velero.yml.j2
+++ b/roles/migrationcontroller/templates/velero.yml.j2
@@ -76,6 +76,18 @@ spec:
               value: {{ mig_namespace }}
             - name: VELERO_SCRATCH_DIR
               value: /scratch
+{% if http_proxy|length >0 %}
+            - name: HTTP_PROXY
+              value: {{ http_proxy }}
+{% endif %}
+{% if https_proxy|length >0 %}
+            - name: HTTPS_PROXY
+              value: {{ https_proxy }}
+{% endif %}
+{% if no_proxy|length >0 %}
+            - name: NO_PROXY
+              value: {{ no_proxy }}
+{% endif %}
       volumes:
         - name: {{ velero_aws_secret_name }}
           secret:
@@ -213,6 +225,18 @@ spec:
             - name: certs
               mountPath: /etc/ssl/certs
           env:
+{% if http_proxy|length >0 %}
+            - name: HTTP_PROXY
+              value: {{ http_proxy }}
+{% endif %}
+{% if https_proxy|length >0 %}
+            - name: HTTPS_PROXY
+              value: {{ https_proxy }}
+{% endif %}
+{% if no_proxy|length >0 %}
+            - name: NO_PROXY
+              value: {{ no_proxy }}
+{% endif %}
             - name: NODE_NAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
This configure proxy env vars if they are set on the operator or in the MigrationController CR.

It does not yet address the issue of certificates.

For each of the following check the box when you have verified either:
* the changes have been made for each applicable version
* no changes are required for the item

Affected versions:
* [x] Latest
* [ ] 1.1
* [ ] 1.0

The CSV is responsible in OLM installs for
* [x] Operator permissions
* [x] Operator deployment
* [x] Operand permissions
* [x] CRDs

The operator.yml is responsible in non-OLM installs for
* [x] Operator permissions
* [x] Operator deployment

The ansible role is responsible in non-OLM installs for:
* [x] Operand permissions
* [x] CRDs

The ansible role is always responsible for:
* [x] Operand deployment

If this PR updates a release or replaces channel 
* [x] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [x] I updated channels in the `konveyor-operator.package.yaml`
* [x] I created a new release directory in `deploy/non-olm`
* [x] I created or updated the major.minor link in `deploy/non-olm`
* [x] Updated the `.github/pull_request_template.md` Affected versions list
