### PR TITLE
Update MigPlan CRD to use GVK instead of GVR

### DIFF
--- a/deploy/olm-catalog/konveyor-operator/v1.2.0/migplan.crd.yaml
+++ b/deploy/olm-catalog/konveyor-operator/v1.2.0/migplan.crd.yaml
@@ -96,26 +96,26 @@ spec:
             incompatibleNamespaces:
               items:
                 properties:
-                  gvrs:
+                  gvks:
                     items:
                       properties:
                         group:
                           type: string
-                        resource:
+                        kind:
                           type: string
                         version:
                           type: string
                       required:
                       - group
                       - version
-                      - resource
+                      - kind
                       type: object
                     type: array
                   name:
                     type: string
                 required:
                 - name
-                - gvrs
+                - gvks
                 type: object
               type: array
             observedGeneration:

--- a/roles/migrationcontroller/files/migration_v1alpha1_migplan.yaml
+++ b/roles/migrationcontroller/files/migration_v1alpha1_migplan.yaml
@@ -96,26 +96,26 @@ spec:
             incompatibleNamespaces:
               items:
                 properties:
-                  gvrs:
+                  gvks:
                     items:
                       properties:
                         group:
                           type: string
-                        resource:
+                        kind:
                           type: string
                         version:
                           type: string
                       required:
                       - group
                       - version
-                      - resource
+                      - kind
                       type: object
                     type: array
                   name:
                     type: string
                 required:
                 - name
-                - gvrs
+                - gvks
                 type: object
               type: array
             observedGeneration:


### PR DESCRIPTION
**Required update to keep up with controller change in https://github.com/konveyor/mig-controller/pull/453**

**I noticed this was an issue when I saw controller failure testing a GVK exclusion feature.**

For each of the following check the box when you have verified either:
* the changes have been made for each applicable version
* no changes are required for the item

Affected versions:
* [x] Latest
* [ ] 1.1
* [ ] 1.0

The CSV is responsible in OLM installs for
* [ ] Operator permissions
* [ ] Operator deployment
* [ ] Operand permissions
* [x] CRDs

The operator.yml is responsible in non-OLM installs for
* [ ] Operator permissions
* [ ] Operator deployment

The ansible role is responsible in non-OLM installs for:
* [ ] Operand permissions
* [x] CRDs

The ansible role is always responsible for:
* [ ] Operand deployment

If this PR updates a release or replaces channel 
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] Updated the `.github/pull_request_template.md` Affected versions list
