### PR TITLE
Support verify for restic/filesystem PV copy

### DIFF
--- a/deploy/olm-catalog/konveyor-operator/v1.2.0/migplan.crd.yaml
+++ b/deploy/olm-catalog/konveyor-operator/v1.2.0/migplan.crd.yaml
@@ -66,6 +66,8 @@ spec:
                         type: string
                       storageClass:
                         type: string
+                      verify:
+                        type: boolean
                     type: object
                   storageClass:
                     type: string

--- a/roles/migrationcontroller/files/migration_v1alpha1_migplan.yaml
+++ b/roles/migrationcontroller/files/migration_v1alpha1_migplan.yaml
@@ -66,6 +66,8 @@ spec:
                         type: string
                       storageClass:
                         type: string
+                      verify:
+                        type: boolean
                     type: object
                   storageClass:
                     type: string

--- a/roles/migrationcontroller/templates/velero.yml.j2
+++ b/roles/migrationcontroller/templates/velero.yml.j2
@@ -217,6 +217,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: VELERO_NAMESPACE
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
Two operator changes:
1) Added Verify to PV.Selection
2) added POD_NAME env var to restic DaemonSet

This is dependent on: https://github.com/konveyor/mig-controller/pull/467

For each of the following check the box when you have verified either:
* the changes have been made for each applicable version
* no changes are required for the item

Affected versions:
* [ x] Latest
* [N/A ] 1.1
* [N/A ] 1.0

The CSV is responsible in OLM installs for
* [N/A ] Operator permissions
* [N/A ] Operator deployment
* [N/A ] Operand permissions
* [ x] CRDs

The operator.yml is responsible in non-OLM installs for
* [N/A ] Operator permissions
* [N/A ] Operator deployment

The ansible role is responsible in non-OLM installs for:
* [N/A ] Operand permissions
* [X ] CRDs

The ansible role is always responsible for:
* [ ] Operand deployment

If this PR updates a release or replaces channel 
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] Updated the `.github/pull_request_template.md` Affected versions list
