### PR TITLE
Fix migration registry fqin variable name typo

### DIFF
--- a/roles/migrationcontroller/templates/controller.yml.j2
+++ b/roles/migrationcontroller/templates/controller.yml.j2
@@ -81,7 +81,7 @@ spec:
         - name: SECRET_NAME
           value: webhook-server-secret
         - name: MIGRATION_REGISTRY_IMAGE
-          value: {{ migraiton_registry_image_fqin }}
+          value: {{ migration_registry_image_fqin }}
         envFrom:
         - configMapRef:
             name: migration-controller


### PR DESCRIPTION
@jmontleon I'm not confident that I'm filling out the checkboxes below correctly, but this fixes a typo in var naming with the new image fqins introduced in https://github.com/konveyor/mig-operator/blob/75209aa921b4d7e399be9749a7f340375a29d75b/roles/migrationcontroller/templates/controller.yml.j2#L84

I was trying to run mig-operator to test out Danil's GVK exclusion PR, hit install error during playbook due to this.

---

**For each of the following check the box when you have verified either:**
* **the changes have been made for each applicable version**
* **no changes are required for the item**
* **PR's that are submitted without running through the list below will be CLOSED**

Affected versions:
* [x] Latest
* [ ] 1.1
* [ ] 1.0

The CSV is responsible in OLM installs for
* [ ] Operator permissions
* [ ] Operator deployment
* [ ] Operand permissions
* [ ] CRDs

The operator.yml is responsible in non-OLM installs for
* [ ] Operator permissions
* [ ] Operator deployment

The ansible role is responsible in non-OLM installs for:
* [ ] Operand permissions
* [ ] CRDs

The ansible role is always responsible for:
* [ ] Operand deployment

If this PR updates a release or replaces channel 
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] Updated the `.github/pull_request_template.md` Affected versions list
