### PR TITLE
Sync the CRDS in the ansible role with the ones in the OLM dir

### DIFF
--- a/roles/migrationcontroller/files/migration_v1alpha1_migcluster.yaml
+++ b/roles/migrationcontroller/files/migration_v1alpha1_migcluster.yaml
@@ -33,6 +33,8 @@ spec:
             caBundle:
               format: byte
               type: string
+            insecure:
+              type: boolean
             isHostCluster:
               type: boolean
             serviceAccountSecretRef:

--- a/roles/migrationcontroller/files/migration_v1alpha1_migstorage.yaml
+++ b/roles/migrationcontroller/files/migration_v1alpha1_migstorage.yaml
@@ -54,6 +54,8 @@ spec:
                   type: object
                 gcpBucket:
                   type: string
+                insecure:
+                  type: boolean
                 s3CustomCABundle:
                   format: byte
                   type: string


### PR DESCRIPTION
**For each of the following check the box when you have verified either:**
* **the changes have been made for each applicable version**
* **no changes are required for the item**
* **PR's that are submitted without running through the list below will be CLOSED**

Affected versions:
* [x] Latest
* [ ] 1.1
* [ ] 1.0

The CSV is responsible in OLM installs for
* [x] Operator permissions
* [x] Operator deployment
* [x] Operand permissions
* [x] CRDs

The operator.yml is responsible in non-OLM installs for
* [x] Operator permissions
* [x] Operator deployment

The ansible role is responsible in non-OLM installs for:
* [x] Operand permissions
* [x] CRDs

The ansible role is always responsible for:
* [x] Operand deployment

If this PR updates a release or replaces channel 
* [x] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [x] I updated channels in the `konveyor-operator.package.yaml`
* [x] I created a new release directory in `deploy/non-olm`
* [x] I created or updated the major.minor link in `deploy/non-olm`
* [x] Updated the `.github/pull_request_template.md` Affected versions list
