### PR TITLE
Workaround for ansible-operator issue #2648

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -9,7 +9,11 @@ RUN echo -ne "[centos-8-appstream]\nname = CentOS 8 (RPMs) - AppStream\nbaseurl 
 RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
  && yum -y install python3-boto3 \
  && yum clean all
+
+RUN ln -s ${HOME}/.ansible /.ansible
+
 USER 1001
+
 COPY build/requirements.yml ${HOME}/requirements.yml
 RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \
  && chmod -R ug+rwx ${HOME}/.ansible

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -7,10 +7,11 @@ RUN yum -y update && yum clean all
 RUN echo -ne "[centos-8-appstream]\nname = CentOS 8 (RPMs) - AppStream\nbaseurl = http://mirror.centos.org/centos-8/8/AppStream/x86_64/os/\nenabled = 1\ngpgcheck = 0" > /etc/yum.repos.d/centos.repo
 
 RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
- && yum -y install python3-boto3 \
+ && yum -y install python3-boto3 nss_wrapper \
  && yum clean all
 
 RUN ln -s ${HOME}/.ansible /.ansible
+COPY build/entrypoint /usr/local/bin/entrypoint
 
 USER 1001
 

--- a/build/entrypoint
+++ b/build/entrypoint
@@ -1,0 +1,20 @@
+#!/bin/bash -e
+
+USER_ID=$(id -u)
+
+if [ x"$USER_ID" != x"0" -a x"$USER_ID" != x"1001" ]; then
+    NSS_WRAPPER_PASSWD=/tmp/passwd.nss_wrapper
+    NSS_WRAPPER_GROUP=/etc/group
+
+    cp /etc/passwd $NSS_WRAPPER_PASSWD
+
+    echo "${USER_NAME:-ansible-operator}:x:$(id -u):0:${USER_NAME:-apb} user:${HOME}:/sbin/nologin" >> $NSS_WRAPPER_PASSWD
+
+    export NSS_WRAPPER_PASSWD
+    export NSS_WRAPPER_GROUP
+
+    LD_PRELOAD=/usr/lib64/libnss_wrapper.so
+    export LD_PRELOAD
+fi
+
+exec ${OPERATOR} exec-entrypoint ansible --watches-file=/opt/ansible/watches.yaml $@


### PR DESCRIPTION
This PR introduces a workaround for https://github.com/operator-framework/operator-sdk/issues/2648

We saw this on a 4.3.1 cluster at least once.

**For each of the following check the box when you have verified either:**
* **the changes have been made for each applicable version**
* **no changes are required for the item**
* **PR's that are submitted without running through the list below will be CLOSED**

Affected versions:
* [X] Latest
* [ ] 1.1
* [ ] 1.0

The CSV is responsible in OLM installs for
* [X] Operator permissions
* [X] Operator deployment
* [X] Operand permissions
* [X] CRDs

The operator.yml is responsible in non-OLM installs for
* [X] Operator permissions
* [X] Operator deployment

The ansible role is responsible in non-OLM installs for:
* [X] Operand permissions
* [X] CRDs

The ansible role is always responsible for:
* [X] Operand deployment

If this PR updates a release or replaces channel 
* [X] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [X] I updated channels in the `konveyor-operator.package.yaml`
* [X] I created a new release directory in `deploy/non-olm`
* [X] I created or updated the major.minor link in `deploy/non-olm`
* [X] Updated the `.github/pull_request_template.md` Affected versions list
