### PR TITLE
Replaced ObservedGeneration with ObservedDigest.

### DIFF
--- a/deploy/olm-catalog/konveyor-operator/v1.2.0/migcluster.crd.yaml
+++ b/deploy/olm-catalog/konveyor-operator/v1.2.0/migcluster.crd.yaml
@@ -60,6 +60,9 @@ spec:
           - isHostCluster
           type: object
         status:
+          properties:
+            observedDigest:
+              type: string
           type: object
   version: v1alpha1
 status:

--- a/deploy/olm-catalog/konveyor-operator/v1.2.0/migmigration.crd.yaml
+++ b/deploy/olm-catalog/konveyor-operator/v1.2.0/migmigration.crd.yaml
@@ -49,6 +49,8 @@ spec:
               items:
                 type: string
               type: array
+            observedDigest:
+              type: string
             phase:
               type: string
             startTimestamp:

--- a/deploy/olm-catalog/konveyor-operator/v1.2.0/migplan.crd.yaml
+++ b/deploy/olm-catalog/konveyor-operator/v1.2.0/migplan.crd.yaml
@@ -120,9 +120,8 @@ spec:
                 - gvks
                 type: object
               type: array
-            observedGeneration:
-              format: int64
-              type: integer
+            observedDigest:
+              type: string
           type: object
   version: v1alpha1
 status:

--- a/deploy/olm-catalog/konveyor-operator/v1.2.0/migstorage.crd.yaml
+++ b/deploy/olm-catalog/konveyor-operator/v1.2.0/migstorage.crd.yaml
@@ -82,6 +82,9 @@ spec:
           - backupStorageConfig
           type: object
         status:
+          properties:
+            observedDigest:
+              type: string
           type: object
   version: v1alpha1
 status:

--- a/roles/migrationcontroller/files/migration_v1alpha1_migcluster.yaml
+++ b/roles/migrationcontroller/files/migration_v1alpha1_migcluster.yaml
@@ -60,6 +60,9 @@ spec:
           - isHostCluster
           type: object
         status:
+          properties:
+            observedDigest:
+              type: string
           type: object
   version: v1alpha1
 status:

--- a/roles/migrationcontroller/files/migration_v1alpha1_migmigration.yaml
+++ b/roles/migrationcontroller/files/migration_v1alpha1_migmigration.yaml
@@ -49,6 +49,8 @@ spec:
               items:
                 type: string
               type: array
+            observedDigest:
+              type: string
             phase:
               type: string
             startTimestamp:

--- a/roles/migrationcontroller/files/migration_v1alpha1_migplan.yaml
+++ b/roles/migrationcontroller/files/migration_v1alpha1_migplan.yaml
@@ -120,9 +120,8 @@ spec:
                 - gvks
                 type: object
               type: array
-            observedGeneration:
-              format: int64
-              type: integer
+            observedDigest:
+              type: string
           type: object
   version: v1alpha1
 status:

--- a/roles/migrationcontroller/files/migration_v1alpha1_migstorage.yaml
+++ b/roles/migrationcontroller/files/migration_v1alpha1_migstorage.yaml
@@ -82,6 +82,9 @@ spec:
           - backupStorageConfig
           type: object
         status:
+          properties:
+            observedDigest:
+              type: string
           type: object
   version: v1alpha1
 status:


### PR DESCRIPTION
The `generation` field is not managed (incremented) in OCP3 so cannot apply the `observedGeneration` pattern.
Instead, generating a SHA256 (hex) digest for the `Spec` and storing in the status as: `observedDigest`.  Gives us most of the same benefits and compatible with older clusters.

**Requires**: https://github.com/konveyor/mig-controller/pull/475

**For each of the following check the box when you have verified either:**
* **the changes have been made for each applicable version**
* **no changes are required for the item**
* **PR's that are submitted without running through the list below will be CLOSED**

Affected versions:
* [x] Latest
* [ ] 1.1
* [ ] 1.0
* [x] 1.2

The CSV is responsible in OLM installs for
* [ ] Operator permissions
* [ ] Operator deployment
* [ ] Operand permissions
* [x] CRDs

The operator.yml is responsible in non-OLM installs for
* [ ] Operator permissions
* [ ] Operator deployment

The ansible role is responsible in non-OLM installs for:
* [ ] Operand permissions
* [x] CRDs

The ansible role is always responsible for:
* [ ] Operand deployment

If this PR updates a release or replaces channel 
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] Updated the `.github/pull_request_template.md` Affected versions list
