### PR TITLE
Bug 1817559 - Limits not updated

### DIFF
--- a/roles/migrationcontroller/templates/controller.yml.j2
+++ b/roles/migrationcontroller/templates/controller.yml.j2
@@ -62,9 +62,11 @@ spec:
         control-plane: controller-manager
         controller-tools.k8s.io: "1.0"
       annotations:
-        configHash: "{{ (mig_pv_limit | string)
+        configHash: "{{ (cors_origins | string)
+        | join(mig_pv_limit | string)
         | join(mig_pod_limit | string)
         | join(mig_namespace_limit | string)
+        | join(discovery_volume_path | string)
         | hash('sha1') }}"
     spec:
       serviceAccountName: migration-controller


### PR DESCRIPTION
**For each of the following check the box when you have verified either:**
* **the changes have been made for each applicable version**
* **no changes are required for the item**
* **PR's that are submitted without running through the list below will be CLOSED**

Affected versions:
* [ ] Latest
* [x] 1.1
* [x] 1.0

The CSV is responsible in OLM installs for
* [x] Operator permissions
* [x] Operator deployment
* [x] Operand permissions
* [x] CRDs

The operator.yml is responsible in non-OLM installs for
* [x] Operator permissions
* [x] Operator deployment

The ansible role is responsible in non-OLM installs for:
* [x] Operand permissions
* [x] CRDs

The ansible role is always responsible for:
* [ ] Operand deployment

If this PR updates a release or replaces channel 
* [x] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [x] I updated channels in the `konveyor-operator.package.yaml`
* [x] I created a new release directory in `deploy/non-olm`
* [x] I created or updated the major.minor link in `deploy/non-olm`
* [x] Updated the `.github/pull_request_template.md` Affected versions list

 Fixed out of whack hashing function, when the first value in the filters is a single character, the whole join is obsolete, and SHA1 is receiving the same single character no matter what is in the joins.