### PR TITLE
Patch monitoring label onto openshift-migration namespace for OLM managed cases

### DIFF
--- a/roles/migrationcontroller/tasks/main.yml
+++ b/roles/migrationcontroller/tasks/main.yml
@@ -5,6 +5,11 @@
 - block:
   - when: olm_managed
     block:
+
+    - k8s:
+        state: "present"
+        definition: "{{ lookup('template', 'monitoring-namespace-label.yml.j2') }}"
+
     - k8s:
         state: "present"
         definition: "{{ lookup('template', 'migration-controller.yml.j2') }}"

--- a/roles/migrationcontroller/templates/monitoring-namespace-label.yml.j2
+++ b/roles/migrationcontroller/templates/monitoring-namespace-label.yml.j2
@@ -4,5 +4,5 @@ kind: Namespace
 metadata:
   labels:
     openshift.io/cluster-monitoring: "true"
-  name: "{{ meta.namespace }}"
+  name: "{{ mig_namespace }}"
   

--- a/roles/migrationcontroller/templates/monitoring-namespace-label.yml.j2
+++ b/roles/migrationcontroller/templates/monitoring-namespace-label.yml.j2
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    openshift.io/cluster-monitoring: "true"
+  name: "{{ meta.namespace }}"
+  


### PR DESCRIPTION
### Purpose

Goal of this PR is to patch openshift-migration namespace with the required label to be included in on-cluster monitoring system for OLM based installs. This is already taken care of for non-OLM installs.

This gets us into the preometheus scrape list:
![image](https://user-images.githubusercontent.com/7576968/79912177-9e087c00-83ef-11ea-9510-717a31d5c143.png)


![image](https://user-images.githubusercontent.com/7576968/79912114-8630f800-83ef-11ea-8cb9-2451ea033ad0.png)


---

**For each of the following check the box when you have verified either:**
* **the changes have been made for each applicable version**
* **no changes are required for the item**
* **PR's that are submitted without running through the list below will be CLOSED**

Affected versions:
* [x] Latest
* [ ] 1.1
* [ ] 1.0

The CSV is responsible in OLM installs for
* [ ] Operator permissions
* [ ] Operator deployment
* [ ] Operand permissions
* [ ] CRDs

The operator.yml is responsible in non-OLM installs for
* [ ] Operator permissions
* [ ] Operator deployment

The ansible role is responsible in non-OLM installs for:
* [ ] Operand permissions
* [ ] CRDs

The ansible role is always responsible for:
* [ ] Operand deployment

If this PR updates a release or replaces channel 
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] Updated the `.github/pull_request_template.md` Affected versions list
