### PR TITLE
Ininerary status field added to CRD, added missing permissions.

### DIFF
--- a/deploy/olm-catalog/konveyor-operator/v1.2.0/konveyor-operator.v1.2.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/konveyor-operator/v1.2.0/konveyor-operator.v1.2.0.clusterserviceversion.yaml
@@ -589,6 +589,13 @@ spec:
           - update
           - delete
           - deletecollection
+        - apiGroups:
+          - build.openshift.io
+          - rbac.authorization.k8s.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
       - serviceAccountName: velero
         rules:
         - apiGroups:

--- a/deploy/olm-catalog/konveyor-operator/v1.2.0/migmigration.crd.yaml
+++ b/deploy/olm-catalog/konveyor-operator/v1.2.0/migmigration.crd.yaml
@@ -49,6 +49,8 @@ spec:
               items:
                 type: string
               type: array
+            itenerary:
+              type: string
             observedDigest:
               type: string
             phase:

--- a/roles/migrationcontroller/files/migration_v1alpha1_migmigration.yaml
+++ b/roles/migrationcontroller/files/migration_v1alpha1_migmigration.yaml
@@ -49,6 +49,8 @@ spec:
               items:
                 type: string
               type: array
+            itenerary:
+              type: string
             observedDigest:
               type: string
             phase:

--- a/roles/migrationcontroller/templates/mig_rbac.yml.j2
+++ b/roles/migrationcontroller/templates/mig_rbac.yml.j2
@@ -209,6 +209,13 @@ rules:
   - delete
   - update
   - deletecollection
+- apiGroups:
+  - build.openshift.io
+  - rbac.authorization.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
**For each of the following check the box when you have verified either:**
* **the changes have been made for each applicable version**
* **no changes are required for the item**
* **PR's that are submitted without running through the list below will be CLOSED**

Affected versions:
* [ ] Latest
* [x] 1.1
* [x] 1.0

The CSV is responsible in OLM installs for
* [x] Operator permissions
* [x] Operator deployment
* [ ] Operand permissions
* [ ] CRDs

The operator.yml is responsible in non-OLM installs for
* [x] Operator permissions
* [x] Operator deployment

The ansible role is responsible in non-OLM installs for:
* [ ] Operand permissions
* [ ] CRDs

The ansible role is always responsible for:
* [x] Operand deployment

If this PR updates a release or replaces channel 
* [x] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [x] I updated channels in the `konveyor-operator.package.yaml`
* [x] I created a new release directory in `deploy/non-olm`
* [x] I created or updated the major.minor link in `deploy/non-olm`
* [x] Updated the `.github/pull_request_template.md` Affected versions list
