### PR TITLE
Fix velero 1.3.1 CRDs

### DIFF
--- a/deploy/olm-catalog/konveyor-operator/v1.2.0/backup.crd.yaml
+++ b/deploy/olm-catalog/konveyor-operator/v1.2.0/backup.crd.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/deploy/olm-catalog/konveyor-operator/v1.2.0/backupstoragelocation.crd.yaml
+++ b/deploy/olm-catalog/konveyor-operator/v1.2.0/backupstoragelocation.crd.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/deploy/olm-catalog/konveyor-operator/v1.2.0/deletebackuprequest.crd.yaml
+++ b/deploy/olm-catalog/konveyor-operator/v1.2.0/deletebackuprequest.crd.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/deploy/olm-catalog/konveyor-operator/v1.2.0/downloadrequest.crd.yaml
+++ b/deploy/olm-catalog/konveyor-operator/v1.2.0/downloadrequest.crd.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/deploy/olm-catalog/konveyor-operator/v1.2.0/podvolumebackup.crd.yaml
+++ b/deploy/olm-catalog/konveyor-operator/v1.2.0/podvolumebackup.crd.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/deploy/olm-catalog/konveyor-operator/v1.2.0/podvolumerestore.crd.yaml
+++ b/deploy/olm-catalog/konveyor-operator/v1.2.0/podvolumerestore.crd.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/deploy/olm-catalog/konveyor-operator/v1.2.0/resticrepository.crd.yaml
+++ b/deploy/olm-catalog/konveyor-operator/v1.2.0/resticrepository.crd.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/deploy/olm-catalog/konveyor-operator/v1.2.0/restore.crd.yaml
+++ b/deploy/olm-catalog/konveyor-operator/v1.2.0/restore.crd.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/deploy/olm-catalog/konveyor-operator/v1.2.0/schedule.crd.yaml
+++ b/deploy/olm-catalog/konveyor-operator/v1.2.0/schedule.crd.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/deploy/olm-catalog/konveyor-operator/v1.2.0/serverstatusrequest.crd.yaml
+++ b/deploy/olm-catalog/konveyor-operator/v1.2.0/serverstatusrequest.crd.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/deploy/olm-catalog/konveyor-operator/v1.2.0/volumesnapshotlocation.crd.yaml
+++ b/deploy/olm-catalog/konveyor-operator/v1.2.0/volumesnapshotlocation.crd.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:


### PR DESCRIPTION
**For each of the following check the box when you have verified either:**
* **the changes have been made for each applicable version**
* **no changes are required for the item**
* **PR's that are submitted without running through the list below will be CLOSED**

Affected versions:
* [X] Latest
* [ ] 1.1
* [ ] 1.0

The CSV is responsible in OLM installs for
* [X] Operator permissions
* [X] Operator deployment
* [X] Operand permissions
* [X] CRDs

The operator.yml is responsible in non-OLM installs for
* [X] Operator permissions
* [X] Operator deployment

The ansible role is responsible in non-OLM installs for:
* [X] Operand permissions
* [X] CRDs

The ansible role is always responsible for:
* [X] Operand deployment

If this PR updates a release or replaces channel 
* [X] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [X] I updated channels in the `konveyor-operator.package.yaml`
* [X] I created a new release directory in `deploy/non-olm`
* [X] I created or updated the major.minor link in `deploy/non-olm`
* [X] Updated the `.github/pull_request_template.md` Affected versions list
