### PR TITLE
Update hacking.md with OperatorGroup creation instructions

### DIFF
--- a/docs/hacking.md
+++ b/docs/hacking.md
@@ -54,7 +54,7 @@ EOF
 oc create -f mig-operator-source.yaml
 ```
 
-## Disabling default operator sources
+## Disabling default OperatorSources
 If you are working on an operator such as konveyor, that exists in community-operators or elsewhere you may see duplicate operators in the UI. It can be difficult to discern which copy comes from which source. To alleviate this problem you may disable the default operator sources.
 ```
 oc patch OperatorHub cluster --type json -p '[{"op": "add", "path": "/spec/disableAllDefaultSources", "value": true}]'
@@ -65,7 +65,22 @@ To reverse this change simply update the value again.
 oc patch OperatorHub cluster --type json -p '[{"op": "add", "path": "/spec/disableAllDefaultSources", "value": false}]'
 ```
 
-## Creating the subscription
+## Creating the OperatorGroup
+Before creating a subscription from the CLI, you must create an OperatorGroup.
+
+```
+cat << EOF > operatorgroup.yml
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  generateName: openshift-migration-
+spec:
+  targetNamespaces:
+  - openshift-migration
+EOF
+```
+
+## Creating the Subscription
 You may either create the subscription via the UI console or from the CLI.
 
 To do so from the CLI, ensure the namespace exists, select a channel, write a subscription.yml, and create the resource.


### PR DESCRIPTION
### **Problem:** 
konveyor-operator won't deploy via OLM without an OperatorGroup on my OCP 4.3 cluster. 

OperatorGroup is created automatically when creating a subscription from the Web Console.

### Linked Issue
Resolves https://github.com/konveyor/mig-operator/issues/307

---


**For each of the following check the box when you have verified either:**
* **the changes have been made for each applicable version**
* **no changes are required for the item**
* **PR's that are submitted without running through the list below will be CLOSED**

Affected versions:
* [x] Latest
* [x] 1.1
* [x] 1.0

The CSV is responsible in OLM installs for
* [ ] Operator permissions
* [ ] Operator deployment
* [ ] Operand permissions
* [ ] CRDs

The operator.yml is responsible in non-OLM installs for
* [ ] Operator permissions
* [ ] Operator deployment

The ansible role is responsible in non-OLM installs for:
* [ ] Operand permissions
* [ ] CRDs

The ansible role is always responsible for:
* [ ] Operand deployment

If this PR updates a release or replaces channel 
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] Updated the `.github/pull_request_template.md` Affected versions list
