### PR TITLE
Added CRD change to migrate all PVC (including without a pod mount)

### DIFF
--- a/deploy/olm-catalog/konveyor-operator/v1.2.0/migplan.crd.yaml
+++ b/deploy/olm-catalog/konveyor-operator/v1.2.0/migplan.crd.yaml
@@ -69,6 +69,8 @@ spec:
                         items:
                           type: string
                         type: array
+                      hasReference:
+                        type: boolean
                       name:
                         type: string
                       namespace:

--- a/roles/migrationcontroller/files/migration_v1alpha1_migplan.yaml
+++ b/roles/migrationcontroller/files/migration_v1alpha1_migplan.yaml
@@ -69,6 +69,8 @@ spec:
                         items:
                           type: string
                         type: array
+                      hasReference:
+                        type: boolean
                       name:
                         type: string
                       namespace:


### PR DESCRIPTION
**For each of the following check the box when you have verified either:**
* **the changes have been made for each applicable version**
* **no changes are required for the item**
* **PR's that are submitted without running through the list below will be CLOSED**

Affected versions:
* [ ] Latest
* [x] 1.1
* [x] 1.0

The CSV is responsible in OLM installs for
* [x] Operator permissions
* [x] Operator deployment
* [x] Operand permissions
* [ ] CRDs

The operator.yml is responsible in non-OLM installs for
* [x] Operator permissions
* [x] Operator deployment

The ansible role is responsible in non-OLM installs for:
* [x] Operand permissions
* [ ] CRDs

The ansible role is always responsible for:
* [x] Operand deployment

If this PR updates a release or replaces channel 
* [x] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [x] I updated channels in the `konveyor-operator.package.yaml`
* [x] I created a new release directory in `deploy/non-olm`
* [x] I created or updated the major.minor link in `deploy/non-olm`
* [x] Updated the `.github/pull_request_template.md` Affected versions list
