### PR TITLE
add skips so older CSVs will be loaded and can be pinned

### DIFF
--- a/deploy/olm-catalog/konveyor-operator/v1.0.1/konveyor-operator.v1.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/konveyor-operator/v1.0.1/konveyor-operator.v1.0.1.clusterserviceversion.yaml
@@ -172,6 +172,8 @@ metadata:
     certified: "false"
     support: Red Hat
 spec:
+  skips:
+  - konveyor-operator.v1.0.0
   relatedImages:
   - name: controller
     image: quay.io/ocpmigrate/mig-controller:release-1.0

--- a/deploy/olm-catalog/konveyor-operator/v1.1.2/konveyor-operator.v1.1.2.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/konveyor-operator/v1.1.2/konveyor-operator.v1.1.2.clusterserviceversion.yaml
@@ -173,6 +173,9 @@ metadata:
     certified: "false"
     support: Red Hat
 spec:
+  skips:
+  - konveyor-operator.v1.1.1
+  - konveyor-operator.v1.1.0
   relatedImages:
   - name: controller
     image: quay.io/ocpmigrate/mig-controller:latest


### PR DESCRIPTION
**For each of the following check the box when you have verified either:**
* **the changes have been made for each applicable version**
* **no changes are required for the item**
* **PR's that are submitted without running through the list below will be CLOSED**

Affected versions:
* [ ] Latest
* [X] 1.1
* [X] 1.0

The CSV is responsible in OLM installs for
* [X] Operator permissions
* [X] Operator deployment
* [X] Operand permissions
* [X] CRDs

The operator.yml is responsible in non-OLM installs for
* [X] Operator permissions
* [X] Operator deployment

The ansible role is responsible in non-OLM installs for:
* [X] Operand permissions
* [X] CRDs

The ansible role is always responsible for:
* [X] Operand deployment

If this PR updates a release or replaces channel 
* [X] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [X] I updated channels in the `konveyor-operator.package.yaml`
* [X] I created a new release directory in `deploy/non-olm`
* [X] I created or updated the major.minor link in `deploy/non-olm`
* [X] Updated the `.github/pull_request_template.md` Affected versions list