### PR TITLE
additional fixes to downstream-prep

### DIFF
--- a/deploy/downstream-prep.sh
+++ b/deploy/downstream-prep.sh
@@ -7,6 +7,9 @@ fi
 sed -i s,konveyor-operator,cam-operator,g deploy/olm-catalog/konveyor-operator/konveyor-operator.package.yaml
 rm -rf deploy/olm-catalogstable deploy/olm-catalog/konveyor-operator/latest
 
+#deal with k8s_status change upstream/downstream
+sed -i 's/operator_sdk\.util\.//g' roles/migrationcontroller/tasks/main.yml
+
 if [ -d deploy/olm-catalog/konveyor-operator/v1.2.0 ]; then
   #Declare v1.2 image information
   V1_2_IMAGES=(


### PR DESCRIPTION
**For each of the following check the box when you have verified either:**
* **the changes have been made for each applicable version**
* **no changes are required for the item**
* **PR's that are submitted without running through the list below will be CLOSED**

Affected versions:
* [ ] Latest
* [ ] 1.1
* [ ] 1.0

The CSV is responsible in OLM installs for
* [X] Operator permissions
* [X] Operator deployment
* [X] Operand permissions
* [X] CRDs

The operator.yml is responsible in non-OLM installs for
* [X] Operator permissions
* [X] Operator deployment

The ansible role is responsible in non-OLM installs for:
* [X] Operand permissions
* [X] CRDs

The ansible role is always responsible for:
* [X] Operand deployment

If this PR updates a release or replaces channel 
* [X] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [X] I updated channels in the `konveyor-operator.package.yaml`
* [X] I created a new release directory in `deploy/non-olm`
* [X] I created or updated the major.minor link in `deploy/non-olm`
* [X] Updated the `.github/pull_request_template.md` Affected versions list
