### PR TITLE
template out validations on old OCP 3.x releases

### DIFF
--- a/roles/migrationcontroller/templates/velero_supporting.yml.j2
+++ b/roles/migrationcontroller/templates/velero_supporting.yml.j2
@@ -15,6 +15,7 @@ spec:
     singular: backup
   preserveUnknownFields: false
   scope: Namespaced
+{% if lookup('k8s', cluster_info='version').kubernetes.minor|replace('+', '')|int < 11 %}
   validation:
     openAPIV3Schema:
       description: Backup is a Velero resource that respresents the capture of Kubernetes
@@ -382,6 +383,7 @@ spec:
               type: integer
           type: object
       type: object
+{% endif %}
   version: v1
   versions:
   - name: v1
@@ -410,6 +412,7 @@ spec:
     singular: schedule
   preserveUnknownFields: false
   scope: Namespaced
+{% if lookup('k8s', cluster_info='version').kubernetes.minor|replace('+', '')|int < 11 %}
   validation:
     openAPIV3Schema:
       description: Schedule is a Velero resource that represents a pre-scheduled or
@@ -756,6 +759,7 @@ spec:
               type: array
           type: object
       type: object
+{% endif %}
   version: v1
   versions:
   - name: v1
@@ -784,6 +788,7 @@ spec:
     singular: restore
   preserveUnknownFields: false
   scope: Namespaced
+{% if lookup('k8s', cluster_info='version').kubernetes.minor|replace('+', '')|int < 11 %}
   validation:
     openAPIV3Schema:
       description: Restore is a Velero resource that represents the application of
@@ -1030,6 +1035,7 @@ spec:
               type: integer
           type: object
       type: object
+{% endif %}
   version: v1
   versions:
   - name: v1
@@ -1058,6 +1064,7 @@ spec:
     singular: downloadrequest
   preserveUnknownFields: false
   scope: Namespaced
+{% if lookup('k8s', cluster_info='version').kubernetes.minor|replace('+', '')|int < 11 %}
   validation:
     openAPIV3Schema:
       description: DownloadRequest is a request to download an artifact from backup
@@ -1123,6 +1130,7 @@ spec:
               type: string
           type: object
       type: object
+{% endif %}
   version: v1
   versions:
   - name: v1
@@ -1151,6 +1159,7 @@ spec:
     singular: deletebackuprequest
   preserveUnknownFields: false
   scope: Namespaced
+{% if lookup('k8s', cluster_info='version').kubernetes.minor|replace('+', '')|int < 11 %}
   validation:
     openAPIV3Schema:
       description: DeleteBackupRequest is a request to delete one or more backups.
@@ -1195,6 +1204,7 @@ spec:
               type: string
           type: object
       type: object
+{% endif %}
   version: v1
   versions:
   - name: v1
@@ -1223,6 +1233,7 @@ spec:
     singular: podvolumebackup
   preserveUnknownFields: false
   scope: Namespaced
+{% if lookup('k8s', cluster_info='version').kubernetes.minor|replace('+', '')|int < 11 %}
   validation:
     openAPIV3Schema:
       properties:
@@ -1356,6 +1367,7 @@ spec:
               type: string
           type: object
       type: object
+{% endif %}
   version: v1
   versions:
   - name: v1
@@ -1384,6 +1396,7 @@ spec:
     singular: podvolumerestore
   preserveUnknownFields: false
   scope: Namespaced
+{% if lookup('k8s', cluster_info='version').kubernetes.minor|replace('+', '')|int < 11 %}
   validation:
     openAPIV3Schema:
       properties:
@@ -1515,6 +1528,7 @@ spec:
               type: integer
           type: object
       type: object
+{% endif %}
   version: v1
   versions:
   - name: v1
@@ -1543,6 +1557,7 @@ spec:
     singular: resticrepository
   preserveUnknownFields: false
   scope: Namespaced
+{% if lookup('k8s', cluster_info='version').kubernetes.minor|replace('+', '')|int < 11 %}
   validation:
     openAPIV3Schema:
       properties:
@@ -1603,6 +1618,7 @@ spec:
               type: string
           type: object
       type: object
+{% endif %}
   version: v1
   versions:
   - name: v1
@@ -1631,6 +1647,7 @@ spec:
     singular: backupstoragelocation
   preserveUnknownFields: false
   scope: Namespaced
+{% if lookup('k8s', cluster_info='version').kubernetes.minor|replace('+', '')|int < 11 %}
   validation:
     openAPIV3Schema:
       description: BackupStorageLocation is a location where Velero stores backup
@@ -1723,6 +1740,7 @@ spec:
               type: string
           type: object
       type: object
+{% endif %}
   version: v1
   versions:
   - name: v1
@@ -1751,6 +1769,7 @@ spec:
     singular: volumesnapshotlocation
   preserveUnknownFields: false
   scope: Namespaced
+{% if lookup('k8s', cluster_info='version').kubernetes.minor|replace('+', '')|int < 11 %}
   validation:
     openAPIV3Schema:
       description: VolumeSnapshotLocation is a location where Velero stores volume
@@ -1796,6 +1815,7 @@ spec:
               type: string
           type: object
       type: object
+{% endif %}
   version: v1
   versions:
   - name: v1
@@ -1824,6 +1844,7 @@ spec:
     singular: serverstatusrequest
   preserveUnknownFields: false
   scope: Namespaced
+{% if lookup('k8s', cluster_info='version').kubernetes.minor|replace('+', '')|int < 11 %}
   validation:
     openAPIV3Schema:
       description: ServerStatusRequest is a request to access current status information
@@ -1880,6 +1901,7 @@ spec:
               type: string
           type: object
       type: object
+{% endif %}
   version: v1
   versions:
   - name: v1


### PR DESCRIPTION
**For each of the following check the box when you have verified either:**
* **the changes have been made for each applicable version**
* **no changes are required for the item**
* **PR's that are submitted without running through the list below will be CLOSED**

Affected versions:
* [X] Latest
* [ ] 1.1
* [ ] 1.0

The CSV is responsible in OLM installs for
* [X] Operator permissions
* [X] Operator deployment
* [X] Operand permissions
* [X] CRDs

The operator.yml is responsible in non-OLM installs for
* [X] Operator permissions
* [X] Operator deployment

The ansible role is responsible in non-OLM installs for:
* [X] Operand permissions
* [X] CRDs

The ansible role is always responsible for:
* [X] Operand deployment

If this PR updates a release or replaces channel 
* [X] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [X] I updated channels in the `konveyor-operator.package.yaml`
* [X] I created a new release directory in `deploy/non-olm`
* [X] I created or updated the major.minor link in `deploy/non-olm`
* [X] Updated the `.github/pull_request_template.md` Affected versions list
