### PR TITLE
Fix inverted conditionals

### DIFF
--- a/roles/migrationcontroller/templates/velero_supporting.yml.j2
+++ b/roles/migrationcontroller/templates/velero_supporting.yml.j2
@@ -15,7 +15,7 @@ spec:
     singular: backup
   preserveUnknownFields: false
   scope: Namespaced
-{% if lookup('k8s', cluster_info='version').kubernetes.minor|replace('+', '')|int < 11 %}
+{% if lookup('k8s', cluster_info='version').kubernetes.minor|replace('+', '')|int > 10 %}
   validation:
     openAPIV3Schema:
       description: Backup is a Velero resource that respresents the capture of Kubernetes
@@ -412,7 +412,7 @@ spec:
     singular: schedule
   preserveUnknownFields: false
   scope: Namespaced
-{% if lookup('k8s', cluster_info='version').kubernetes.minor|replace('+', '')|int < 11 %}
+{% if lookup('k8s', cluster_info='version').kubernetes.minor|replace('+', '')|int > 10 %}
   validation:
     openAPIV3Schema:
       description: Schedule is a Velero resource that represents a pre-scheduled or
@@ -788,7 +788,7 @@ spec:
     singular: restore
   preserveUnknownFields: false
   scope: Namespaced
-{% if lookup('k8s', cluster_info='version').kubernetes.minor|replace('+', '')|int < 11 %}
+{% if lookup('k8s', cluster_info='version').kubernetes.minor|replace('+', '')|int > 10 %}
   validation:
     openAPIV3Schema:
       description: Restore is a Velero resource that represents the application of
@@ -1064,7 +1064,7 @@ spec:
     singular: downloadrequest
   preserveUnknownFields: false
   scope: Namespaced
-{% if lookup('k8s', cluster_info='version').kubernetes.minor|replace('+', '')|int < 11 %}
+{% if lookup('k8s', cluster_info='version').kubernetes.minor|replace('+', '')|int > 10 %}
   validation:
     openAPIV3Schema:
       description: DownloadRequest is a request to download an artifact from backup
@@ -1159,7 +1159,7 @@ spec:
     singular: deletebackuprequest
   preserveUnknownFields: false
   scope: Namespaced
-{% if lookup('k8s', cluster_info='version').kubernetes.minor|replace('+', '')|int < 11 %}
+{% if lookup('k8s', cluster_info='version').kubernetes.minor|replace('+', '')|int > 10 %}
   validation:
     openAPIV3Schema:
       description: DeleteBackupRequest is a request to delete one or more backups.
@@ -1233,7 +1233,7 @@ spec:
     singular: podvolumebackup
   preserveUnknownFields: false
   scope: Namespaced
-{% if lookup('k8s', cluster_info='version').kubernetes.minor|replace('+', '')|int < 11 %}
+{% if lookup('k8s', cluster_info='version').kubernetes.minor|replace('+', '')|int > 10 %}
   validation:
     openAPIV3Schema:
       properties:
@@ -1396,7 +1396,7 @@ spec:
     singular: podvolumerestore
   preserveUnknownFields: false
   scope: Namespaced
-{% if lookup('k8s', cluster_info='version').kubernetes.minor|replace('+', '')|int < 11 %}
+{% if lookup('k8s', cluster_info='version').kubernetes.minor|replace('+', '')|int > 10 %}
   validation:
     openAPIV3Schema:
       properties:
@@ -1557,7 +1557,7 @@ spec:
     singular: resticrepository
   preserveUnknownFields: false
   scope: Namespaced
-{% if lookup('k8s', cluster_info='version').kubernetes.minor|replace('+', '')|int < 11 %}
+{% if lookup('k8s', cluster_info='version').kubernetes.minor|replace('+', '')|int > 10 %}
   validation:
     openAPIV3Schema:
       properties:
@@ -1647,7 +1647,7 @@ spec:
     singular: backupstoragelocation
   preserveUnknownFields: false
   scope: Namespaced
-{% if lookup('k8s', cluster_info='version').kubernetes.minor|replace('+', '')|int < 11 %}
+{% if lookup('k8s', cluster_info='version').kubernetes.minor|replace('+', '')|int > 10 %}
   validation:
     openAPIV3Schema:
       description: BackupStorageLocation is a location where Velero stores backup
@@ -1769,7 +1769,7 @@ spec:
     singular: volumesnapshotlocation
   preserveUnknownFields: false
   scope: Namespaced
-{% if lookup('k8s', cluster_info='version').kubernetes.minor|replace('+', '')|int < 11 %}
+{% if lookup('k8s', cluster_info='version').kubernetes.minor|replace('+', '')|int > 10 %}
   validation:
     openAPIV3Schema:
       description: VolumeSnapshotLocation is a location where Velero stores volume
@@ -1844,7 +1844,7 @@ spec:
     singular: serverstatusrequest
   preserveUnknownFields: false
   scope: Namespaced
-{% if lookup('k8s', cluster_info='version').kubernetes.minor|replace('+', '')|int < 11 %}
+{% if lookup('k8s', cluster_info='version').kubernetes.minor|replace('+', '')|int > 10 %}
   validation:
     openAPIV3Schema:
       description: ServerStatusRequest is a request to access current status information


### PR DESCRIPTION
**For each of the following check the box when you have verified either:**
* **the changes have been made for each applicable version**
* **no changes are required for the item**
* **PR's that are submitted without running through the list below will be CLOSED**

Affected versions:
* [X] Latest
* [ ] 1.1
* [ ] 1.0

The CSV is responsible in OLM installs for
* [X] Operator permissions
* [X] Operator deployment
* [X] Operand permissions
* [X] CRDs

The operator.yml is responsible in non-OLM installs for
* [X] Operator permissions
* [X] Operator deployment

The ansible role is responsible in non-OLM installs for:
* [X] Operand permissions
* [X] CRDs

The ansible role is always responsible for:
* [X] Operand deployment

If this PR updates a release or replaces channel 
* [X] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [X] I updated channels in the `konveyor-operator.package.yaml`
* [X] I created a new release directory in `deploy/non-olm`
* [X] I created or updated the major.minor link in `deploy/non-olm`
* [X] Updated the `.github/pull_request_template.md` Affected versions list