### PR TITLE
add resource limits for noobaa endpoint pods

### DIFF
--- a/roles/migrationcontroller/defaults/main.yml
+++ b/roles/migrationcontroller/defaults/main.yml
@@ -82,3 +82,6 @@ noobaa_system_core_cpu: 0.5
 noobaa_system_core_mem: 500Mi
 noobaa_system_db_cpu: 0.5
 noobaa_system_db_mem: 1Gi
+noobaa_system_endpoints_cpu: 1
+noobaa_system_endpoints_mem: 500Mi
+noobaa_system_endpoints_pod_count: 2

--- a/roles/migrationcontroller/templates/noobaa_system.yml.j2
+++ b/roles/migrationcontroller/templates/noobaa_system.yml.j2
@@ -15,3 +15,10 @@ spec:
    requests:
      cpu: {{ noobaa_system_core_cpu }}
      memory: {{ noobaa_system_core_mem }}
+ endpoints:
+   maxCount: {{ noobaa_system_endpoints_pod_count }}
+   minCount: {{ noobaa_system_endpoints_pod_count }}
+   resources:
+     requests:
+       cpu: {{ noobaa_system_endpoints_cpu }}
+       memory: {{ noobaa_system_endpoints_mem }}


### PR DESCRIPTION
**For each of the following check the box when you have verified either:**
* **the changes have been made for each applicable version**
* **no changes are required for the item**
* **PR's that are submitted without running through the list below will be CLOSED**

Affected versions:
* [x] Latest
* [ ] 1.1
* [ ] 1.0

The CSV is responsible in OLM installs for
* [x] Operator permissions
* [x] Operator deployment
* [x] Operand permissions
* [x] CRDs

The operator.yml is responsible in non-OLM installs for
* [x] Operator permissions
* [x] Operator deployment

The ansible role is responsible in non-OLM installs for:
* [x] Operand permissions
* [x] CRDs

The ansible role is always responsible for:
* [x] Operand deployment

If this PR updates a release or replaces channel 
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] Updated the `.github/pull_request_template.md` Affected versions list
