### PR TITLE
Bug 1833531 - Fully qualify route to prevent issues with knative

### DIFF
--- a/roles/migrationcontroller/templates/discovery.yml.j2
+++ b/roles/migrationcontroller/templates/discovery.yml.j2
@@ -16,7 +16,7 @@ spec:
     control-plane: controller-manager
     controller-tools.k8s.io: "1.0"
 ---
-apiVersion: v1
+apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   labels:


### PR DESCRIPTION
**For each of the following check the box when you have verified either:**
* **the changes have been made for each applicable version**
* **no changes are required for the item**
* **PR's that are submitted without running through the list below will be CLOSED**

Affected versions:
* [X] Latest
* [X] 1.2
* [ ] 1.1

The CSV is responsible in OLM installs for
* [X] Operator permissions
* [X] Operator deployment
* [X] Operand permissions
* [X] CRDs

The operator.yml is responsible in non-OLM installs for
* [X] Operator permissions
* [X] Operator deployment

The ansible role is responsible in non-OLM installs for:
* [X] Operand permissions
* [X] CRDs

The ansible role is always responsible for:
* [X] Operand deployment

If this PR updates a release or replaces channel 
* [X] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [X] I updated channels in the `konveyor-operator.package.yaml`
* [X] I created a new release directory in `deploy/non-olm`
* [X] I created or updated the major.minor link in `deploy/non-olm`
* [X] Updated the `.github/pull_request_template.md` Affected versions list
