### PR TITLE
Add cluster scoped blacklist for non-admin usage

### DIFF
--- a/roles/migrationcontroller/defaults/main.yml
+++ b/roles/migrationcontroller/defaults/main.yml
@@ -83,3 +83,13 @@ noobaa_system_core_cpu: 0.5
 noobaa_system_core_mem: 500Mi
 noobaa_system_db_cpu: 0.5
 noobaa_system_db_mem: 1Gi
+
+# Non admin configuration
+tenant_cluster_scoped_blacklist: []
+# Possible values for blacklist:
+  #  - persistentvolumes
+  #  - clusterresourcequotas
+  #  - securitycontextconstraints
+  #  - clusterrolebindings
+  #  - clusterroles
+  #  - customresourcedefinitions

--- a/roles/migrationcontroller/templates/controller.yml.j2
+++ b/roles/migrationcontroller/templates/controller.yml.j2
@@ -162,6 +162,10 @@ spec:
           value: {{ mig_namespace }}
         - name: SANDBOX_NAMESPACE
           value: {{ sandbox_namespace }}
+{% if tenant_cluster_scoped_blacklist|length >0 %}
+        - name: CLUSTER_SCOPED_BLACKLIST
+          value: {{ tenant_cluster_scoped_blacklist|join(',') }}
+{% endif %}
         envFrom:
         - configMapRef:
             name: migration-controller


### PR DESCRIPTION
**For each of the following check the box when you have verified either:**
* **the changes have been made for each applicable version**
* **no changes are required for the item**
* **PR's that are submitted without running through the list below will be CLOSED**

Affected versions:
* [x] Latest
* [ ] 1.1
* [ ] 1.0

The CSV is responsible in OLM installs for
* [ ] Operator permissions
* [ ] Operator deployment
* [ ] Operand permissions
* [ ] CRDs

The operator.yml is responsible in non-OLM installs for
* [ ] Operator permissions
* [ ] Operator deployment

The ansible role is responsible in non-OLM installs for:
* [ ] Operand permissions
* [ ] CRDs

The ansible role is always responsible for:
* [x] Operand deployment

If this PR updates a release or replaces channel 
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] Updated the `.github/pull_request_template.md` Affected versions list
