### PR TITLE
Add MigToken CRD and update controller role

### DIFF
--- a/deploy/olm-catalog/konveyor-operator/latest/migplan.crd.yaml
+++ b/deploy/olm-catalog/konveyor-operator/latest/migplan.crd.yaml
@@ -32,6 +32,8 @@ spec:
               type: boolean
             destMigClusterRef:
               type: object
+            destMigTokenRef:
+              type: object
             hooks:
               items:
                 properties:
@@ -109,6 +111,8 @@ spec:
                 type: object
               type: array
             srcMigClusterRef:
+              type: object
+            srcMigTokenRef:
               type: object
           type: object
         status:

--- a/deploy/olm-catalog/konveyor-operator/latest/migtoken.crd.yaml
+++ b/deploy/olm-catalog/konveyor-operator/latest/migtoken.crd.yaml
@@ -1,0 +1,50 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: migtokens.migration.openshift.io
+spec:
+  group: migration.openshift.io
+  names:
+    kind: MigToken
+    plural: migtokens
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            migClusterRef:
+              type: object
+            secretRef:
+              type: object
+          required:
+          - secretRef
+          - migClusterRef
+          type: object
+        status:
+          properties:
+            observedDigest:
+              type: string
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/roles/migrationcontroller/files/migration_v1alpha1_migplan.yaml
+++ b/roles/migrationcontroller/files/migration_v1alpha1_migplan.yaml
@@ -32,7 +32,7 @@ spec:
               type: boolean
             destMigClusterRef:
               type: object
-            identitySecretRef:
+            destMigTokenRef:
               type: object
             hooks:
               items:
@@ -111,6 +111,8 @@ spec:
                 type: object
               type: array
             srcMigClusterRef:
+              type: object
+            srcMigTokenRef:
               type: object
           type: object
         status:

--- a/roles/migrationcontroller/files/migration_v1alpha1_migtoken.yaml
+++ b/roles/migrationcontroller/files/migration_v1alpha1_migtoken.yaml
@@ -1,0 +1,50 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: migtokens.migration.openshift.io
+spec:
+  group: migration.openshift.io
+  names:
+    kind: MigToken
+    plural: migtokens
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            migClusterRef:
+              type: object
+            secretRef:
+              type: object
+          required:
+          - secretRef
+          - migClusterRef
+          type: object
+        status:
+          properties:
+            observedDigest:
+              type: string
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/roles/migrationcontroller/templates/controller.yml.j2
+++ b/roles/migrationcontroller/templates/controller.yml.j2
@@ -86,7 +86,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: ROLE
-          value: cluster,plan,migration,storage
+          value: cluster,plan,migration,storage,token
         - name: OPERATOR_NAMESPACE
           value: {{ mig_namespace }}
 {% if reconcile_migrationtenant %}


### PR DESCRIPTION
Adds the MigToken CRD, updates the MigPlan CRD to reflect the MigToken changes, and updates the controller role to include `token`.

See https://github.com/konveyor/mig-controller/pull/526

**For each of the following check the box when you have verified either:**
* **the changes have been made for each applicable version**
* **no changes are required for the item**
* **PR's that are submitted without running through the list below will be CLOSED**

Affected versions:
* [x] Latest
* [ ] 1.1
* [ ] 1.0

The CSV is responsible in OLM installs for
* [x] Operator permissions
* [x] Operator deployment
* [x] Operand permissions
* [x] CRDs

The operator.yml is responsible in non-OLM installs for
* [x] Operator permissions
* [x] Operator deployment

The ansible role is responsible in non-OLM installs for:
* [x] Operand permissions
* [x] CRDs

The ansible role is always responsible for:
* [x] Operand deployment

If this PR updates a release or replaces channel 
* [x] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [x] I updated channels in the `konveyor-operator.package.yaml`
* [x] I created a new release directory in `deploy/non-olm`
* [x] I created or updated the major.minor link in `deploy/non-olm`
* [x] Updated the `.github/pull_request_template.md` Affected versions list
