### PR TITLE
Fully qualify route API in k8s_facts lookups

### DIFF
--- a/roles/migrationcontroller/tasks/main.yml
+++ b/roles/migrationcontroller/tasks/main.yml
@@ -209,7 +209,7 @@
 
   - name: Check if mig ui route exists already so we don't update it
     k8s_facts:
-      api_version: v1
+      api_version: "route.openshift.io/v1"
       kind: Route
       name: migration
       namespace: "{{ mig_namespace }}"
@@ -416,7 +416,7 @@
 
   - name: Check if discovery route exists
     k8s_facts:
-      api_version: v1
+      api_version: "route.openshift.io/v1"
       kind: Route
       name: discovery
       namespace: "{{ mig_namespace }}"


### PR DESCRIPTION
**For each of the following check the box when you have verified either:**
* **the changes have been made for each applicable version**
* **no changes are required for the item**
* **PR's that are submitted without running through the list below will be CLOSED**

Affected versions:
* [X] Latest
* [X] 1.2
* [ ] 1.1

The CSV is responsible in OLM installs for
* [X] Operator permissions
* [X] Operator deployment
* [X] Operand permissions
* [X] CRDs

The operator.yml is responsible in non-OLM installs for
* [X] Operator permissions
* [X] Operator deployment

The ansible role is responsible in non-OLM installs for:
* [X] Operand permissions
* [X] CRDs

The ansible role is always responsible for:
* [X] Operand deployment

If this PR updates a release or replaces channel 
* [X] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [X] I updated channels in the `konveyor-operator.package.yaml`
* [X] I created a new release directory in `deploy/non-olm`
* [X] I created or updated the major.minor link in `deploy/non-olm`
* [X] Updated the `.github/pull_request_template.md` Affected versions list
