### PR TITLE
Include non-admin CRDs in v1.2.0 CSV

### DIFF
--- a/deploy/olm-catalog/konveyor-operator/v1.2.0/migplan.crd.yaml
+++ b/deploy/olm-catalog/konveyor-operator/v1.2.0/migplan.crd.yaml
@@ -32,7 +32,7 @@ spec:
               type: boolean
             destMigClusterRef:
               type: object
-            identitySecretRef:
+            destMigTokenRef:
               type: object
             hooks:
               items:
@@ -111,6 +111,8 @@ spec:
                 type: object
               type: array
             srcMigClusterRef:
+              type: object
+            srcMigTokenRef:
               type: object
           type: object
         status:

--- a/deploy/olm-catalog/konveyor-operator/v1.2.0/migtoken.crd.yaml
+++ b/deploy/olm-catalog/konveyor-operator/v1.2.0/migtoken.crd.yaml
@@ -1,0 +1,50 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: migtokens.migration.openshift.io
+spec:
+  group: migration.openshift.io
+  names:
+    kind: MigToken
+    plural: migtokens
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            migClusterRef:
+              type: object
+            secretRef:
+              type: object
+          required:
+          - secretRef
+          - migClusterRef
+          type: object
+        status:
+          properties:
+            observedDigest:
+              type: string
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []


### PR DESCRIPTION
**For each of the following check the box when you have verified either:**
* **the changes have been made for each applicable version**
* **no changes are required for the item**
* **PR's that are submitted without running through the list below will be CLOSED**

Affected versions:
* [ ] Latest
* [ ] 1.1
* [ ] 1.0

The CSV is responsible in OLM installs for
* [ ] Operator permissions
* [ ] Operator deployment
* [ ] Operand permissions
* [ ] CRDs

The operator.yml is responsible in non-OLM installs for
* [ ] Operator permissions
* [ ] Operator deployment

The ansible role is responsible in non-OLM installs for:
* [ ] Operand permissions
* [ ] CRDs

The ansible role is always responsible for:
* [ ] Operand deployment

If this PR updates a release or replaces channel 
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] Updated the `.github/pull_request_template.md` Affected versions list
