### PR TITLE
WIP: default pv pool based storage when noobaa is enabled

### DIFF
--- a/roles/migrationcontroller/defaults/main.yml
+++ b/roles/migrationcontroller/defaults/main.yml
@@ -82,3 +82,6 @@ noobaa_system_core_cpu: 0.5
 noobaa_system_core_mem: 500Mi
 noobaa_system_db_cpu: 0.5
 noobaa_system_db_mem: 1Gi
+noobaa_system_endpoints_cpu: 1
+noobaa_system_endpoints_mem: 500Mi
+noobaa_system_endpoints_pod_count: 2

--- a/roles/migrationcontroller/defaults/main.yml
+++ b/roles/migrationcontroller/defaults/main.yml
@@ -76,6 +76,12 @@ noobaa_expected_crds:
   - backingstores.noobaa.io
 noobaa_admin_secret: noobaa-admin
 noobaa_system_namespace: "{{ mig_namespace }}"
+noobaa_system_pv_pool_bs_name: mig-storage-pv-pool-backing-store
+noobaa_system_pool_pv_quantity: 3
+noobaa_system_pv_pool_pv_size: 50Gi
+noobaa_system_pv_pool_pv_storageclass: gp2
+noobaa_system_pv_pool_bc_name: mig-storage-pv-pool-backing-class
+noobaa_system_pv_pool_bucket_name: mig-store-bucket
 noobaa_mig_bucket_name: mig-storage
 noobaa_s3_endpoint_proto: http
 noobaa_system_core_cpu: 0.5

--- a/roles/migrationcontroller/tasks/mcg.yml
+++ b/roles/migrationcontroller/tasks/mcg.yml
@@ -138,21 +138,50 @@
       AWS_ACCESS_KEY_ID: "{{ noobaa_s3_access_key_id }}"
       AWS_SECRET_ACCESS_KEY: "{{ noobaa_s3_secret_access_key }}"
     block:
-    - name: Creating bucket for migstorage
-      aws_s3:
-        bucket: "{{ noobaa_mig_bucket_name }}"
-        mode: create
-        s3_url: "{{ noobaa_s3_endpoint_proto }}://{{ noobaa_endpoint }}/"
-        validate_certs: false
-      register: bucket_status
-      retries: 20
-      delay: 3
-      until: not bucket_status.failed
-
-    - name: Creating NooBaa backed migstorage
+    - name: "Create PV Pool BackingStore"
       k8s:
-        state: present
-        definition: "{{ lookup('template', 'mig_storage.yml.j2') }}"
-      vars:
-        noobaa_s3_url: "{{ noobaa_s3_endpoint_proto }}://{{ noobaa_endpoint }}/"
-      when: migration_controller|bool
+        state: "present"
+        definition: "{{ lookup('template', 'pv_pool_backingstore.yml.j2') }}"
+
+    - name: "Create PV Pool BucketClass"
+      k8s:
+        state: "present"
+        definition: "{{ lookup('template', 'pv_pool_bucketclass.yml.j2') }}"
+
+    - name: "Create PV Pool ObjectBucketClaim"
+      k8s:
+        state: "present"
+        definition: "{{ lookup('template', 'pv_pool_objectbucketclaim.yml.j2') }}"
+
+    - name: "Wait for Bucket to exist"
+      k8s_facts:
+        api_version: "objectbucket.io/v1alpha1"
+        kind: ObjectBucketClaim
+        name: "{{ noobaa_system_pv_pool_bucket_name }}"
+        namespace: "{{ noobaa_system_namespace }}"
+      register: bucket
+      until: (bucket.resources|length) > 0
+      retries: 30
+      delay: 10
+
+    - name: "Wait for Bucket to have status"
+      k8s_facts:
+        api_version: "objectbucket.io/v1alpha1"
+        kind: ObjectBucketClaim
+        name: "{{ noobaa_system_pv_pool_bucket_name }}"
+        namespace: "{{ noobaa_system_namespace }}"
+      register: bucket
+      until: (bucket.resources|first).status is defined
+      retries: 30
+      delay: 10
+
+    - name: "Wait for Bucket to become bound"
+      k8s_facts:
+        api_version: "objectbucket.io/v1alpha1"
+        kind: ObjectBucketClaim
+        name: "{{ noobaa_system_pv_pool_bucket_name }}"
+        namespace: "{{ noobaa_system_namespace }}"
+      register: bucket
+      until: (bucket.resources|first).status.phase == "Bound"
+      retries: 75
+      delay: 10

--- a/roles/migrationcontroller/templates/noobaa_system.yml.j2
+++ b/roles/migrationcontroller/templates/noobaa_system.yml.j2
@@ -15,3 +15,10 @@ spec:
    requests:
      cpu: {{ noobaa_system_core_cpu }}
      memory: {{ noobaa_system_core_mem }}
+ endpoints:
+   maxCount: {{ noobaa_system_endpoints_pod_count }}
+   minCount: {{ noobaa_system_endpoints_pod_count }}
+   resources:
+     requests:
+       cpu: {{ noobaa_system_endpoints_cpu }}
+       memory: {{ noobaa_system_endpoints_mem }}

--- a/roles/migrationcontroller/templates/pv_pool_backingstore.yml.j2
+++ b/roles/migrationcontroller/templates/pv_pool_backingstore.yml.j2
@@ -1,0 +1,17 @@
+apiVersion: noobaa.io/v1alpha1
+kind: BackingStore
+metadata:
+  finalizers:
+  - noobaa.io/finalizer
+  labels:
+    app: noobaa
+  name: {{ noobaa_system_pv_pool_bs_name }}
+  namespace: {{ noobaa_system_namespace }}
+spec:
+  pvPool:
+    numVolumes: {{ noobaa_system_pool_pv_quantity }}
+    resources:
+      requests:
+        storage: {{ noobaa_system_pv_pool_pv_size }}
+    storageClass: {{ noobaa_system_pv_pool_pv_storageclass }}
+  type: pv-pool

--- a/roles/migrationcontroller/templates/pv_pool_bucketclass.yml.j2
+++ b/roles/migrationcontroller/templates/pv_pool_bucketclass.yml.j2
@@ -1,0 +1,13 @@
+apiVersion: noobaa.io/v1alpha1
+kind: BucketClass
+metadata:
+  labels:
+    app: noobaa
+  name: {{ noobaa_system_pv_pool_bc_name }}
+  namespace: {{ noobaa_system_namespace }}
+spec:
+  placementPolicy:
+    tiers:
+    - backingStores:
+      - mcg-pv-pool-bs
+      placement: Spread

--- a/roles/migrationcontroller/templates/pv_pool_objectbucketclaim.yml.j2
+++ b/roles/migrationcontroller/templates/pv_pool_objectbucketclaim.yml.j2
@@ -1,0 +1,10 @@
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: {{ noobaa_system_pv_pool_bucket_name }}
+  namespace: {{ noobaa_system_namespace }}
+spec:
+  bucketName: migstorage
+  storageClassName: {{ noobaa_system_namespace }}.noobaa.io
+  additionalConfig:
+    bucketclass: {{ noobaa_system_pv_pool_bc_name }}


### PR DESCRIPTION
**For each of the following check the box when you have verified either:**
* **the changes have been made for each applicable version**
* **no changes are required for the item**
* **PR's that are submitted without running through the list below will be CLOSED**

Affected versions:
* [ ] Latest
* [ ] 1.1
* [ ] 1.0

The CSV is responsible in OLM installs for
* [ ] Operator permissions
* [ ] Operator deployment
* [ ] Operand permissions
* [ ] CRDs

The operator.yml is responsible in non-OLM installs for
* [ ] Operator permissions
* [ ] Operator deployment

The ansible role is responsible in non-OLM installs for:
* [ ] Operand permissions
* [ ] CRDs

The ansible role is always responsible for:
* [ ] Operand deployment

If this PR updates a release or replaces channel 
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] Updated the `.github/pull_request_template.md` Affected versions list
