### PR TITLE
add conditional status updates for migtenant and migcontroller CRs

### DIFF
--- a/roles/migrationcontroller/tasks/main.yml
+++ b/roles/migrationcontroller/tasks/main.yml
@@ -502,8 +502,8 @@
         state: "{{ ui_state }}"
         definition: "{{ lookup('template', 'ui.yml.j2') }}"
 
-  - when: (migration_controller is defined and migration_controller) or 
-      (migration_ui is defined and migration_ui)
+  - when: reconcile_migrationcontroller and ((migration_controller is defined and migration_controller) or
+      (migration_ui is defined and migration_ui))
     name: "Set up host MigCluster"
     k8s:
       state: "present"
@@ -590,7 +590,16 @@
       namespace: "{{ meta.namespace }}"
       status:
         phase: Reconciled
-    when: olm_managed and reconciled
+    when: reconcile_migrationcontroller and olm_managed and reconciled
+
+  - operator_sdk.util.k8s_status:
+      api_version: migration.openshift.io/v1alpha1
+      kind: MigrationTenant
+      name: "{{ meta.name }}"
+      namespace: "{{ meta.namespace }}"
+      status:
+        phase: Reconciled
+    when: reconcile_migrationtenant and olm_managed and reconciled
 
   - operator_sdk.util.k8s_status:
       api_version: migration.openshift.io/v1alpha1
@@ -599,7 +608,7 @@
       namespace: "{{ meta.namespace }}"
       status:
         phase: Failed
-    when: olm_managed and not reconciled
+    when: reconcile_migrationcontroller and olm_managed and not reconciled
 
   - name: Retrieve migrationController status
     k8s_facts:
@@ -608,7 +617,7 @@
       namespace: "{{ mig_namespace }}"
     register: controller
 
-  - when: olm_managed and
+  - when:  reconcile_migrationcontroller and olm_managed and
           controller.resources is defined and
           controller.resources[0].status.conditions is defined
     block:


### PR DESCRIPTION
**For each of the following check the box when you have verified either:**
* **the changes have been made for each applicable version**
* **no changes are required for the item**
* **PR's that are submitted without running through the list below will be CLOSED**

Affected versions:
* [x] Latest
* [ ] 1.1
* [ ] 1.0

The CSV is responsible in OLM installs for
* [ ] Operator permissions
* [ ] Operator deployment
* [ ] Operand permissions
* [ ] CRDs

The operator.yml is responsible in non-OLM installs for
* [ ] Operator permissions
* [ ] Operator deployment

The ansible role is responsible in non-OLM installs for:
* [ ] Operand permissions
* [ ] CRDs

The ansible role is always responsible for:
* [ ] Operand deployment

If this PR updates a release or replaces channel 
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] Updated the `.github/pull_request_template.md` Affected versions list
