### PR TITLE
Fix TENANT_NAMESPACE env vars

### DIFF
--- a/roles/migrationcontroller/defaults/main.yml
+++ b/roles/migrationcontroller/defaults/main.yml
@@ -22,7 +22,6 @@ mig_pv_limit: "100"
 mig_pod_limit: "100"
 mig_namespace_limit: "10"
 mig_namespace: "{{ lookup( 'env', 'OPERATOR_NAMESPACE') | default('openshift-migration') }}"
-tenant_namespace: "{{ lookup( 'env', 'TENANT_NAMESPACE') | default('openshift-migration', true) }}"
 mig_ui_cluster_api_endpoint: ""
 mig_ui_configmap_data: ""
 mig_ui_configmap_name: mig-ui-config

--- a/roles/migrationcontroller/templates/controller.yml.j2
+++ b/roles/migrationcontroller/templates/controller.yml.j2
@@ -89,10 +89,8 @@ spec:
           value: cluster,plan,migration,storage,token
         - name: OPERATOR_NAMESPACE
           value: {{ mig_namespace }}
-{% if reconcile_migrationtenant %}
         - name: TENANT_NAMESPACE
           value: {{ meta.namespace }}
-{% endif %}
         - name: SECRET_NAME
           value: webhook-server-secret
         - name: MIGRATION_REGISTRY_IMAGE
@@ -158,10 +156,8 @@ spec:
 {% endif %}
         - name: PRIVILEGED_NAMESPACE
           value: {{ mig_namespace }}
-{% if reconcile_migrationtenant %}
         - name: TENANT_NAMESPACE
           value: {{ meta.namespace }}
-{% endif %}
         envFrom:
         - configMapRef:
             name: migration-controller

--- a/roles/migrationcontroller/templates/controller.yml.j2
+++ b/roles/migrationcontroller/templates/controller.yml.j2
@@ -111,8 +111,6 @@ spec:
 {% endif %}
         - name: PRIVILEGED_NAMESPACE
           value: {{ mig_namespace }}
-        - name: TENANT_NAMESPACE
-          value: {{ tenant_namespace }}
         envFrom:
         - configMapRef:
             name: migration-controller
@@ -160,8 +158,10 @@ spec:
 {% endif %}
         - name: PRIVILEGED_NAMESPACE
           value: {{ mig_namespace }}
+{% if reconcile_migrationtenant %}
         - name: TENANT_NAMESPACE
-          value: {{ tenant_namespace }}
+          value: {{ meta.namespace }}
+{% endif %}
         envFrom:
         - configMapRef:
             name: migration-controller


### PR DESCRIPTION
**For each of the following check the box when you have verified either:**
* **the changes have been made for each applicable version**
* **no changes are required for the item**
* **PR's that are submitted without running through the list below will be CLOSED**

Affected versions:
* [x] Latest
* [ ] 1.1
* [ ] 1.0

The CSV is responsible in OLM installs for
* [ ] Operator permissions
* [x] Operator deployment
* [ ] Operand permissions
* [ ] CRDs

The operator.yml is responsible in non-OLM installs for
* [ ] Operator permissions
* [ ] Operator deployment

The ansible role is responsible in non-OLM installs for:
* [ ] Operand permissions
* [ ] CRDs

The ansible role is always responsible for:
* [x] Operand deployment

If this PR updates a release or replaces channel 
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] Updated the `.github/pull_request_template.md` Affected versions list
