### PR TITLE
add MigrationTenant CRD for non-olm deployment

### DIFF
--- a/deploy/non-olm/v1.2.0/operator.yml
+++ b/deploy/non-olm/v1.2.0/operator.yml
@@ -102,17 +102,16 @@ spec:
   group: migration.openshift.io
   names:
     kind: MigrationTenant
-    listKind: MigrationTenants
+    listKind: MigrationTenantList
     plural: migrationtenants
     singular: migrationtenant
   scope: Namespaced
   subresources:
     status: {}
-  version: v1alpha1
   versions:
-    - name: v1alpha1
-      served: true
-      storage: true
+  - name: v1alpha1
+    served: true
+    storage: true
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role


### PR DESCRIPTION
**For each of the following check the box when you have verified either:**
* **the changes have been made for each applicable version**
* **no changes are required for the item**
* **PR's that are submitted without running through the list below will be CLOSED**

Affected versions:
* [x] Latest
* [ ] 1.1
* [ ] 1.0

The CSV is responsible in OLM installs for
* [ ] Operator permissions
* [ ] Operator deployment
* [ ] Operand permissions
* [ ] CRDs

The operator.yml is responsible in non-OLM installs for
* [ ] Operator permissions
* [ ] Operator deployment
* [x] CRDs

The ansible role is responsible in non-OLM installs for:
* [ ] Operand permissions
* [ ] CRDs

The ansible role is always responsible for:
* [ ] Operand deployment

If this PR updates a release or replaces channel 
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] Updated the `.github/pull_request_template.md` Affected versions list
