### PR TITLE
Support restic restart changes in mig-controller

### DIFF
--- a/deploy/olm-catalog/konveyor-operator/latest/migcluster.crd.yaml
+++ b/deploy/olm-catalog/konveyor-operator/latest/migcluster.crd.yaml
@@ -37,6 +37,8 @@ spec:
               type: boolean
             isHostCluster:
               type: boolean
+            restartRestic:
+              type: boolean
             serviceAccountSecretRef:
               type: object
             storageClasses:

--- a/roles/migrationcontroller/files/migration_v1alpha1_migcluster.yaml
+++ b/roles/migrationcontroller/files/migration_v1alpha1_migcluster.yaml
@@ -37,6 +37,8 @@ spec:
               type: boolean
             isHostCluster:
               type: boolean
+            restartRestic:
+              type: boolean
             serviceAccountSecretRef:
               type: object
             storageClasses:

--- a/roles/migrationcontroller/templates/mig_host_cluster.yml.j2
+++ b/roles/migrationcontroller/templates/mig_host_cluster.yml.j2
@@ -8,4 +8,7 @@ spec:
 {% if azure_resource_group != '' %}
   azureResourceGroup: "{{ azure_resource_group }}"
 {% endif %}
+{% if host_cluster_restart_restic is defined %}
+  restartRestic: "{{ host_cluster_restart_restic }}"
+{% endif %}
   isHostCluster: true


### PR DESCRIPTION
**Required for merge of https://github.com/konveyor/mig-controller/pull/549**
This change is targeted at upcoming **1.2.1. release**

@jmontleon given that this is aimed at 1.2.1 release, do I need to create any new z-steam dirs?

Affected versions:
* [x] Latest
* [x] 1.2.1
* [ ] 1.2
* [ ] 1.1
* [ ] 1.0

The CSV is responsible in OLM installs for
* [ ] Operator permissions
* [ ] Operator deployment
* [ ] Operand permissions
* [x] CRDs

The operator.yml is responsible in non-OLM installs for
* [ ] Operator permissions
* [ ] Operator deployment

The ansible role is responsible in non-OLM installs for:
* [ ] Operand permissions
* [x] CRDs

The ansible role is always responsible for:
* [x] Operand deployment

If this PR updates a release or replaces channel 
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] Updated the `.github/pull_request_template.md` Affected versions list
