### PR TITLE
add MigrationTenant CRD for non-olm deployment and other fixups

### DIFF
--- a/deploy/non-olm/v1.2.0/operator.yml
+++ b/deploy/non-olm/v1.2.0/operator.yml
@@ -94,6 +94,26 @@ spec:
     served: true
     storage: true
 ---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: migrationtenants.migration.openshift.io
+spec:
+  group: migration.openshift.io
+  names:
+    kind: MigrationTenant
+    listKind: MigrationTenants
+    plural: migrationtenants
+    singular: migrationtenant
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
@@ -194,14 +214,14 @@ spec:
         - /usr/local/bin/ao-logs
         - /tmp/ansible-operator/runner
         - stdout
-        image: quay.io/konveyor/mig-operator-container:latest
+        image: quay.io/konveyor/mig-operator-container:non-admin
         imagePullPolicy: Always
         volumeMounts:
         - mountPath: /tmp/ansible-operator/runner
           name: runner
           readOnly: true
       - name: operator
-        image: quay.io/konveyor/mig-operator-container:latest
+        image: quay.io/konveyor/mig-operator-container:non-admin
         imagePullPolicy: Always
         volumeMounts:
         - mountPath: /tmp/ansible-operator/runner
@@ -209,6 +229,10 @@ spec:
         env:
         - name: OPERATOR_NAME
           value: migration-operator
+        - name: OPERATOR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: POD_NAME
           valueFrom:
             fieldRef:


### PR DESCRIPTION
**For each of the following check the box when you have verified either:**
* **the changes have been made for each applicable version**
* **no changes are required for the item**
* **PR's that are submitted without running through the list below will be CLOSED**

Affected versions:
* [x] Latest
* [ ] 1.1
* [ ] 1.0

The CSV is responsible in OLM installs for
* [ ] Operator permissions
* [ ] Operator deployment
* [ ] Operand permissions
* [ ] CRDs

The operator.yml is responsible in non-OLM installs for
* [ ] Operator permissions
* [ ] Operator deployment

The ansible role is responsible in non-OLM installs for:
* [ ] Operand permissions
* [ ] CRDs

The ansible role is always responsible for:
* [ ] Operand deployment

If this PR updates a release or replaces channel 
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] Updated the `.github/pull_request_template.md` Affected versions list
