### PR TITLE
fixed typo in HOOK_RUNNER env variable

### DIFF
--- a/deploy/non-olm/latest/operator.yml
+++ b/deploy/non-olm/latest/operator.yml
@@ -223,7 +223,7 @@ spec:
           value: konveyor
         - name: HOOK_RUNNER_REPO
           value: hook-runner
-        - NAME: HOOK_RUNNER_TAG
+        - name: HOOK_RUNNER_TAG
           value: latest
         - name: MIG_CONTROLLER_REPO
           value: mig-controller

--- a/deploy/non-olm/v1.2.0/operator.yml
+++ b/deploy/non-olm/v1.2.0/operator.yml
@@ -223,7 +223,7 @@ spec:
           value: konveyor
         - name: HOOK_RUNNER_REPO
           value: hook-runner
-        - NAME: HOOK_RUNNER_TAG
+        - name: HOOK_RUNNER_TAG
           value: release-1.2.0
         - name: MIG_CONTROLLER_REPO
           value: mig-controller

--- a/deploy/olm-catalog/konveyor-operator/latest/konveyor-operator.v99.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/konveyor-operator/latest/konveyor-operator.v99.0.0.clusterserviceversion.yaml
@@ -697,7 +697,7 @@ spec:
                   value: konveyor
                 - name: HOOK_RUNNER_REPO
                   value: hook-runner
-                - NAME: HOOK_RUNNER_TAG
+                - name: HOOK_RUNNER_TAG
                   value: latest
                 - name: MIG_CONTROLLER_REPO
                   value: mig-controller

--- a/deploy/olm-catalog/konveyor-operator/v1.2.0/konveyor-operator.v1.2.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/konveyor-operator/v1.2.0/konveyor-operator.v1.2.0.clusterserviceversion.yaml
@@ -697,7 +697,7 @@ spec:
                   value: konveyor
                 - name: HOOK_RUNNER_REPO
                   value: hook-runner
-                - NAME: HOOK_RUNNER_TAG
+                - name: HOOK_RUNNER_TAG
                   value: release-1.2.0
                 - name: MIG_CONTROLLER_REPO
                   value: mig-controller


### PR DESCRIPTION
**For each of the following check the box when you have verified either:**
* **the changes have been made for each applicable version**
* **no changes are required for the item**
* **PR's that are submitted without running through the list below will be CLOSED**

Affected versions:
* [x] Latest
* [ ] 1.1
* [ ] 1.0

The CSV is responsible in OLM installs for
* [ ] Operator permissions
* [ ] Operator deployment
* [ ] Operand permissions
* [ ] CRDs

The operator.yml is responsible in non-OLM installs for
* [ ] Operator permissions
* [ ] Operator deployment

The ansible role is responsible in non-OLM installs for:
* [ ] Operand permissions
* [ ] CRDs

The ansible role is always responsible for:
* [ ] Operand deployment

If this PR updates a release or replaces channel 
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] Updated the `.github/pull_request_template.md` Affected versions list
