### PR TITLE
Remove '-q' on 'docker pull' lines in deploy/downstream-prep.sh

### DIFF
--- a/deploy/downstream-prep.sh
+++ b/deploy/downstream-prep.sh
@@ -46,11 +46,11 @@ if [ -d deploy/olm-catalog/konveyor-operator/v1.2.2 ]; then
 
   #Get latest 1.2 images
   for i in ${V1_2_IMAGES[@]}; do
-    docker pull -q registry-proxy.engineering.redhat.com/rh-osbs/rhcam-${V1_2_IMG_MAP[${i}_repo]}:v1.2 2>/dev/null
+    docker pull registry-proxy.engineering.redhat.com/rh-osbs/rhcam-${V1_2_IMG_MAP[${i}_repo]}:v1.2 2>/dev/null
     DOCKER_STAT=$?
     RETRIES=10
     while [ "$DOCKER_STAT" -ne 0 ] && [ $RETRIES -gt 0 ]; do
-      docker pull -q registry-proxy.engineering.redhat.com/rh-osbs/rhcam-${V1_2_IMG_MAP[${i}_repo]}:v1.2 2>/dev/null
+      docker pull registry-proxy.engineering.redhat.com/rh-osbs/rhcam-${V1_2_IMG_MAP[${i}_repo]}:v1.2 2>/dev/null
       DOCKER_STAT=$?
       let RETRIES=RETRIES-1
     done
@@ -164,9 +164,9 @@ if [ -d deploy/olm-catalog/konveyor-operator/v1.1.2 ]; then
 
   #Get latest 1.1 images
   for i in ${V1_1_IMAGES[@]}; do
-    docker pull -q registry-proxy.engineering.redhat.com/rh-osbs/rhcam-${V1_1_IMG_MAP[${i}_repo]}:v1.1 2>/dev/null
+    docker pull registry-proxy.engineering.redhat.com/rh-osbs/rhcam-${V1_1_IMG_MAP[${i}_repo]}:v1.1 2>/dev/null
     while [ "$DOCKER_STAT" -ne 0 ] && [ $RETRIES -gt 0 ]; do
-      docker pull -q registry-proxy.engineering.redhat.com/rh-osbs/rhcam-${V1_1_IMG_MAP[${i}_repo]}:v1.1 2>/dev/null
+      docker pull registry-proxy.engineering.redhat.com/rh-osbs/rhcam-${V1_1_IMG_MAP[${i}_repo]}:v1.1 2>/dev/null
       DOCKER_STAT=$?
       let RETRIES=RETRIES-1
     done

--- a/deploy/downstream-prep.sh
+++ b/deploy/downstream-prep.sh
@@ -46,11 +46,11 @@ if [ -d deploy/olm-catalog/konveyor-operator/v1.2.2 ]; then
 
   #Get latest 1.2 images
   for i in ${V1_2_IMAGES[@]}; do
-    docker pull registry-proxy.engineering.redhat.com/rh-osbs/rhcam-${V1_2_IMG_MAP[${i}_repo]}:v1.2 2>/dev/null
+    docker pull registry-proxy.engineering.redhat.com/rh-osbs/rhcam-${V1_2_IMG_MAP[${i}_repo]}:v1.2 >/dev/null 2>&1
     DOCKER_STAT=$?
     RETRIES=10
     while [ "$DOCKER_STAT" -ne 0 ] && [ $RETRIES -gt 0 ]; do
-      docker pull registry-proxy.engineering.redhat.com/rh-osbs/rhcam-${V1_2_IMG_MAP[${i}_repo]}:v1.2 2>/dev/null
+      docker pull registry-proxy.engineering.redhat.com/rh-osbs/rhcam-${V1_2_IMG_MAP[${i}_repo]}:v1.2 >/dev/null 2>&1
       DOCKER_STAT=$?
       let RETRIES=RETRIES-1
     done
@@ -164,9 +164,9 @@ if [ -d deploy/olm-catalog/konveyor-operator/v1.1.2 ]; then
 
   #Get latest 1.1 images
   for i in ${V1_1_IMAGES[@]}; do
-    docker pull registry-proxy.engineering.redhat.com/rh-osbs/rhcam-${V1_1_IMG_MAP[${i}_repo]}:v1.1 2>/dev/null
+    docker pull registry-proxy.engineering.redhat.com/rh-osbs/rhcam-${V1_1_IMG_MAP[${i}_repo]}:v1.1 >/dev/null 2>&1
     while [ "$DOCKER_STAT" -ne 0 ] && [ $RETRIES -gt 0 ]; do
-      docker pull registry-proxy.engineering.redhat.com/rh-osbs/rhcam-${V1_1_IMG_MAP[${i}_repo]}:v1.1 2>/dev/null
+      docker pull registry-proxy.engineering.redhat.com/rh-osbs/rhcam-${V1_1_IMG_MAP[${i}_repo]}:v1.1 >/dev/null 2>&1
       DOCKER_STAT=$?
       let RETRIES=RETRIES-1
     done


### PR DESCRIPTION
**Description**

Adding `-q` to `docker pull` lines in deploy/downstream-prep.sh has aggravated my `docker pull` ...

```
unknown shorthand flag: 'q' in -q
See 'docker pull --help'.
```


**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
* [ ] I updated downstream-prep.sh to only update the latest CSV patch version in the channel
