### PR TITLE
pin upstream ansible-operator base image to v0.17.1

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/ansible-operator:latest
+FROM quay.io/operator-framework/ansible-operator:v0.17.1
 
 USER root
 


### PR DESCRIPTION
ansible-operator v0.18.0 removes ao-logs side-car
container, so operator deployment was failing.
We need to pin the base image olde enough so the
side-car is still available as we need it for better
logs downstream

**Description**


**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
* [ ] I updated downstream-prep.sh to only update the latest CSV patch version in the channel
