### PR TITLE
Bug 1844638: Add switch for controlling migration rollback

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ The default limits are:
   - 100 Persistent Volumes per MigPlan
 
 Resource limits can be adjusted by configuring the MigrationController resource responsible for deploying mig-controller.
+
+```
+oc edit MigrationController -n openshift-migration
+```
+
 ```
   [...]
   migration_controller: true
@@ -69,9 +74,14 @@ Resource limits can be adjusted by configuring the MigrationController resource 
 ```
 
 #### Adjusting Rollback on Migration Failure
-Sometimes, an unexpected error will cause a migration to fail. In these scenarios, you can control migration behavior.
+If an unexpected error causes a migration to fail, you can control migration behavior according to your needs.
 
-Automatic rollback behavior can be adjusted by configuring the MigrationController resource responsible for deploying mig-controller.
+Automatic rollback is disabled by default, but can be enabled by configuring the MigrationController resource responsible for deploying mig-controller.
+
+```
+oc edit MigrationController -n openshift-migration
+```
+
 ```
  [...]
  

--- a/README.md
+++ b/README.md
@@ -60,13 +60,39 @@ Resource limits can be adjusted by configuring the MigrationController resource 
   [...]
   migration_controller: true
   
-  # This configuration is loaded into mig-controller, and should be set on the
+  # Resource limit configuration is loaded into mig-controller, and should be set on the
   # cluster where `migration_controller: true`
   mig_pv_limit: 100
   mig_pod_limit: 100
   mig_namespace_limit: 10
   [...]
 ```
+
+#### Adjusting Rollback on Migration Failure
+Sometimes, an unexpected error will cause a migration to fail. In these scenarios, you can control migration behavior.
+
+Automatic rollback behavior can be adjusted by configuring the MigrationController resource responsible for deploying mig-controller.
+```
+ [...]
+ 
+ # Rollback configuration is loaded into mig-controller, and should be set on the
+ # cluster where `migration_controller: true`
+ migration_controller: true
+
+ # [Default] Setting 'mig_failure_rollback: false' leaves the partially migrated workloads 
+ # in place on the target cluster.
+ mig_failure_rollback: false
+
+ # Setting 'mig_failure_rollback: true' removes the partially migrated workloads from the
+ # target cluster and scales them back up on the source cluster.
+ mig_failure_rollback: true
+ [...]
+```
+
+
+
+1. Finish the migration manually by making adjustments to resources on the _target cluster_
+1. _OR_ Automatically delete resources from the _target cluster_ and scale source cluster 
 
 ## CORS (Cross-Origin Resource Sharing) Configuration
 These steps are only required if you are using a Konveyor version older than 1.1.1 OR are installing the controller/UI on OpenShift 3.

--- a/README.md
+++ b/README.md
@@ -89,11 +89,6 @@ Automatic rollback behavior can be adjusted by configuring the MigrationControll
  [...]
 ```
 
-
-
-1. Finish the migration manually by making adjustments to resources on the _target cluster_
-1. _OR_ Automatically delete resources from the _target cluster_ and scale source cluster 
-
 ## CORS (Cross-Origin Resource Sharing) Configuration
 These steps are only required if you are using a Konveyor version older than 1.1.1 OR are installing the controller/UI on OpenShift 3.
 

--- a/deploy/non-olm/latest/controller-4.yml
+++ b/deploy/non-olm/latest/controller-4.yml
@@ -14,6 +14,8 @@ spec:
   mig_pv_limit: 100
   mig_pod_limit: 100
   mig_namespace_limit: 10
+  
+  mig_failure_rollback: false
 
   #Uncomment the following line for OpenShift 4.1
   #deprecated_cors_configuration: true

--- a/deploy/non-olm/v1.2.2/controller-4.yml
+++ b/deploy/non-olm/v1.2.2/controller-4.yml
@@ -15,5 +15,7 @@ spec:
   mig_pod_limit: 100
   mig_namespace_limit: 10
 
+  mig_failure_rollback: false
+
   #Uncomment the following line for OpenShift 4.1
   #deprecated_cors_configuration: true

--- a/deploy/olm-catalog/konveyor-operator/latest/konveyor-operator.v99.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/konveyor-operator/latest/konveyor-operator.v99.0.0.clusterserviceversion.yaml
@@ -31,7 +31,8 @@ metadata:
               "restic_timeout": "1h",
               "mig_pv_limit": "100",
               "mig_pod_limit": "100",
-              "mig_namespace_limit": "10"
+              "mig_namespace_limit": "10",
+              "mig_failure_rollback: false"
             }
         },
         {

--- a/deploy/olm-catalog/konveyor-operator/latest/konveyor-operator.v99.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/konveyor-operator/latest/konveyor-operator.v99.0.0.clusterserviceversion.yaml
@@ -32,7 +32,7 @@ metadata:
               "mig_pv_limit": "100",
               "mig_pod_limit": "100",
               "mig_namespace_limit": "10",
-              "mig_failure_rollback: false"
+              "mig_failure_rollback": false
             }
         },
         {

--- a/deploy/olm-catalog/konveyor-operator/v1.2.2/konveyor-operator.v1.2.2.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/konveyor-operator/v1.2.2/konveyor-operator.v1.2.2.clusterserviceversion.yaml
@@ -31,7 +31,8 @@ metadata:
               "restic_timeout": "1h",
               "mig_pv_limit": "100",
               "mig_pod_limit": "100",
-              "mig_namespace_limit": "10"
+              "mig_namespace_limit": "10",
+              "mig_failure_rollback: false"
             }
         },
         {

--- a/deploy/olm-catalog/konveyor-operator/v1.2.2/konveyor-operator.v1.2.2.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/konveyor-operator/v1.2.2/konveyor-operator.v1.2.2.clusterserviceversion.yaml
@@ -32,7 +32,7 @@ metadata:
               "mig_pv_limit": "100",
               "mig_pod_limit": "100",
               "mig_namespace_limit": "10",
-              "mig_failure_rollback: false"
+              "mig_failure_rollback": false
             }
         },
         {

--- a/roles/migrationcontroller/defaults/main.yml
+++ b/roles/migrationcontroller/defaults/main.yml
@@ -25,6 +25,7 @@ discovery_volume_path: "/var/cache/discovery"
 mig_pv_limit: "100"
 mig_pod_limit: "100"
 mig_namespace_limit: "10"
+mig_failure_rollback: false
 mig_namespace: "{{ lookup( 'env', 'WATCH_NAMESPACE') | default('openshift-migration') }}"
 mig_ui_cluster_api_endpoint: ""
 mig_ui_configmap_data: ""

--- a/roles/migrationcontroller/templates/controller.yml.j2
+++ b/roles/migrationcontroller/templates/controller.yml.j2
@@ -34,6 +34,7 @@ data:
   NAMESPACE_LIMIT: "{{ mig_namespace_limit }}"
   CORS_ALLOWED_ORIGINS: {{ cors_origins | join(' ') }}
   WORKING_DIR: {{ discovery_volume_path }}
+  FAILURE_ROLLBACK: "{{ mig_failure_rollback }}"
 ---
 {% if lookup('k8s', cluster_info='version').kubernetes.minor|replace('+', '')|int < 9 %}
 apiVersion: apps/v1beta1
@@ -67,6 +68,7 @@ spec:
         | join(mig_pod_limit | string)
         | join(mig_namespace_limit | string)
         | join(discovery_volume_path | string)
+        | join(mig_failure_rollback | string)
         | hash('sha1') }}"
     spec:
       serviceAccountName: migration-controller


### PR DESCRIPTION
**Description**
mig-operator change to enable switching rollback on/off in mig-controller

Bound to mig-controller PR: https://github.com/konveyor/mig-controller/pull/560

**Dev Checklist**
- [x] Link to mig-controller PR
- [x] Update mig-operator docs
- [ ] Build mig-operator image and test in OLM context
- [x] Get verification from @jmontleon that I updated the correct files here
- [x] Attach BZ  

**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [x] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
* [ ] I updated downstream-prep.sh to only update the latest CSV patch version in the channel
