### PR TITLE
remove ao-logs container, should land in OpenSfhit 4.5

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/ansible-operator:v0.17.1
+FROM quay.io/operator-framework/ansible-operator:latest
 
 USER root
 

--- a/deploy/non-olm/latest/operator.yml
+++ b/deploy/non-olm/latest/operator.yml
@@ -189,17 +189,6 @@ spec:
     spec:
       serviceAccountName: migration-operator
       containers:
-      - name: ansible
-        command:
-        - /usr/local/bin/ao-logs
-        - /tmp/ansible-operator/runner
-        - stdout
-        image: quay.io/konveyor/mig-operator-container:latest
-        imagePullPolicy: Always
-        volumeMounts:
-        - mountPath: /tmp/ansible-operator/runner
-          name: runner
-          readOnly: true
       - name: operator
         image: quay.io/konveyor/mig-operator-container:latest
         imagePullPolicy: Always

--- a/deploy/olm-catalog/konveyor-operator/latest/konveyor-operator.v99.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/konveyor-operator/latest/konveyor-operator.v99.0.0.clusterserviceversion.yaml
@@ -663,17 +663,6 @@ spec:
             spec:
               serviceAccount: migration-operator
               containers:
-              - name: ansible
-                image: quay.io/konveyor/mig-operator-container:latest
-                command:
-                - /usr/local/bin/ao-logs
-                - /tmp/ansible-operator/runner
-                - stdout
-                imagePullPolicy: Always
-                volumeMounts:
-                - mountPath: /tmp/ansible-operator/runner
-                  name: runner
-                  readOnly: true
               - name: operator
                 image: quay.io/konveyor/mig-operator-container:latest
                 imagePullPolicy: Always


### PR DESCRIPTION
**Description**
Creating a draft PR to remove ao-logs container to latest
so when we get better logs downstream, we can remove
the side-car. As of now this should happen with OpenShift
4.5 (operator-sdk version v0.16.0)

**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [x] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
* [ ] I updated downstream-prep.sh to only update the latest CSV patch version in the channel
