### PR TITLE
Bug 1845361: Remove quotes around bool value for restart restic switch

### DIFF
--- a/roles/migrationcontroller/templates/mig_host_cluster.yml.j2
+++ b/roles/migrationcontroller/templates/mig_host_cluster.yml.j2
@@ -9,6 +9,6 @@ spec:
   azureResourceGroup: "{{ azure_resource_group }}"
 {% endif %}
 {% if host_cluster_restart_restic is defined %}
-  restartRestic: "{{ host_cluster_restart_restic }}"
+  restartRestic: {{ host_cluster_restart_restic }}
 {% endif %}
   isHostCluster: true


### PR DESCRIPTION
**Description**

[BZ 1845361](https://bugzilla.redhat.com/show_bug.cgi?id=1845361)
Fix for the following switch. Removed quotes to allow parsing into golang as a bool
```
host_cluster_restart_restic: true
```

Original Jira - [MIG-243](https://issues.redhat.com/browse/MIG-243)

**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
* [ ] I updated downstream-prep.sh to only update the latest CSV patch version in the channel
