### PR TITLE
Correcting stdout redirection on `oc image mirror` 

### DIFF
--- a/deploy/downstream-prep.sh
+++ b/deploy/downstream-prep.sh
@@ -65,7 +65,7 @@ if [ -d deploy/olm-catalog/konveyor-operator/v1.2.3 ]; then
   for i in ${V1_2_IMAGES[@]}; do
     RETRIES=10
     while [ -z "${V1_2_IMG_MAP[${i}_sha]}" ] && [ $RETRIES -gt 0 ]; do
-      V1_2_IMG_MAP[${i}_sha]=$(oc image mirror --dry-run=true registry-proxy.engineering.redhat.com/rh-osbs/rhcam-${V1_2_IMG_MAP[${i}_repo]}:v1.2=quay.io/ocpmigrate/rhcam-${V1_2_IMG_MAP[${i}_repo]}:v1.2.3>&1 | grep -A1 manifests | grep sha256 | awk -F'[: ]' '{ print $8 }')
+      V1_2_IMG_MAP[${i}_sha]=$(oc image mirror --dry-run=true registry-proxy.engineering.redhat.com/rh-osbs/rhcam-${V1_2_IMG_MAP[${i}_repo]}:v1.2=quay.io/ocpmigrate/rhcam-${V1_2_IMG_MAP[${i}_repo]}:v1.2 2>&1 | grep -A1 manifests | grep sha256 | awk -F'[: ]' '{ print $8 }')
       let RETRIES=RETRIES-1
     done
 


### PR DESCRIPTION
**Description**

Correcting stdout redirection on `oc image mirror` when collecting SHAs.  Appears problem was introduced in https://github.com/konveyor/mig-operator/pull/376 [here](https://github.com/konveyor/mig-operator/pull/376/files#diff-2e2883704003d92166bc8d0fb5078457R68).

**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
* [ ] I updated downstream-prep.sh to only update the latest CSV patch version in the channel
