### PR TITLE
MigPlan CRD changes to add Status.ExcludedResources

### DIFF
--- a/deploy/olm-catalog/konveyor-operator/latest/migplan.crd.yaml
+++ b/deploy/olm-catalog/konveyor-operator/latest/migplan.crd.yaml
@@ -115,6 +115,10 @@ spec:
           type: object
         status:
           properties:
+            excludedResources:
+              items:
+                type: string
+              type: array
             incompatibleNamespaces:
               items:
                 properties:

--- a/roles/migrationcontroller/files/migration_v1alpha1_migplan.yaml
+++ b/roles/migrationcontroller/files/migration_v1alpha1_migplan.yaml
@@ -115,6 +115,10 @@ spec:
           type: object
         status:
           properties:
+            excludedResources:
+              items:
+                type: string
+              type: array
             incompatibleNamespaces:
               items:
                 properties:


### PR DESCRIPTION
**Description**
Added Status.ExcludedResources to MigPlan. This is needed for https://github.com/konveyor/mig-controller/pull/588

**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ X] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
* [ ] I updated downstream-prep.sh to only update the latest CSV patch version in the channel
