### PR TITLE
Exclude namespaced ServiceCatalog kinds

### DIFF
--- a/roles/migrationcontroller/defaults/main.yml
+++ b/roles/migrationcontroller/defaults/main.yml
@@ -11,6 +11,11 @@ excluded_resources:
   - imagetags
   - subscriptions
   - templateinstances
+  - servicebrokers
+  - servicebindings
+  - serviceclasses
+  - serviceinstances
+  - serviceplans
 proxy_secret_name: "migration-proxy"
 http_proxy: "{{ lookup( 'env', 'HTTP_PROXY') }}"
 https_proxy: "{{ lookup( 'env', 'HTTPS_PROXY') }}"


### PR DESCRIPTION
**Description**
This PR adds all namespaced service catalog resources to the default excludes list, some of which are known to cause issues when migrating. The underlying workloads are still migrated, but this breaks their management from a broker, which is acceptable since the brokers are deprecated and/or removed from future versions of open shift depending on the target.

**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
* [ ] I updated downstream-prep.sh to only update the latest CSV patch version in the channel
