### PR TITLE
Use bool filter on values

### DIFF
--- a/roles/migrationcontroller/defaults/main.yml
+++ b/roles/migrationcontroller/defaults/main.yml
@@ -7,10 +7,11 @@ cors_origins: []
 disable_image_migration: false
 disable_pv_migration: false
 excluded_resources:
-  - clusterserviceversions
   - imagetags
-  - subscriptions
   - templateinstances
+  - clusterserviceversions
+  - packagemanifests
+  - subscriptions
   - servicebrokers
   - servicebindings
   - serviceclasses

--- a/roles/migrationcontroller/defaults/main.yml
+++ b/roles/migrationcontroller/defaults/main.yml
@@ -11,6 +11,11 @@ excluded_resources:
   - imagetags
   - subscriptions
   - templateinstances
+  - servicebrokers
+  - servicebindings
+  - serviceclasses
+  - serviceinstances
+  - serviceplans
 proxy_secret_name: "migration-proxy"
 http_proxy: "{{ lookup( 'env', 'HTTP_PROXY') }}"
 https_proxy: "{{ lookup( 'env', 'HTTPS_PROXY') }}"

--- a/roles/migrationcontroller/tasks/main.yml
+++ b/roles/migrationcontroller/tasks/main.yml
@@ -39,15 +39,15 @@
 
   - set_fact:
       all_excluded_resources: "{{ all_excluded_resources + ['imagestreams'] }}"
-    when: disable_image_migration and 'imagestreams' not in excluded_resources
+    when: disable_image_migration|bool and 'imagestreams' not in excluded_resources
 
   - set_fact:
       all_excluded_resources: "{{ all_excluded_resources + ['persistentvolumes'] }}"
-    when: disable_pv_migration and 'persistentvolumes' not in excluded_resources
+    when: disable_pv_migration|bool and 'persistentvolumes' not in excluded_resources
 
   - set_fact:
       all_excluded_resources: "{{ all_excluded_resources + ['persistentvolumeclaims'] }}"
-    when: disable_pv_migration and 'persistentvolumeclaims' not in excluded_resources
+    when: disable_pv_migration|bool and 'persistentvolumeclaims' not in excluded_resources
 
   - name: Get cluster config
     k8s_facts:


### PR DESCRIPTION
**Description**
QE set the value for `disable_pv_migration` to `"false"` rather than `false` and it did not do what they expected. We can protect against this.

**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
* [ ] I updated downstream-prep.sh to only update the latest CSV patch version in the channel
