### PR TITLE
Velero 1.4 CRD changes

### DIFF
--- a/deploy/olm-catalog/konveyor-operator/latest/backup.crd.yaml
+++ b/deploy/olm-catalog/konveyor-operator/latest/backup.crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (unknown)
+    controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: backups.velero.io
 spec:
@@ -338,6 +338,10 @@ spec:
               format: date-time
               nullable: true
               type: string
+            formatVersion:
+              description: FormatVersion is the backup format version, including major,
+                minor, and patch version.
+              type: string
             phase:
               description: Phase is the current state of the Backup.
               enum:
@@ -349,6 +353,24 @@ spec:
               - Failed
               - Deleting
               type: string
+            progress:
+              description: Progress contains information about the backup's execution
+                progress. Note that this information is best-effort only -- if Velero
+                fails to update it during a backup for any reason, it may be inaccurate/stale.
+              nullable: true
+              properties:
+                itemsBackedUp:
+                  description: ItemsBackedUp is the number of items that have actually
+                    been written to the backup tarball so far.
+                  type: integer
+                totalItems:
+                  description: TotalItems is the total number of items to be backed
+                    up. This number may change throughout the execution of the backup
+                    due to plugins that return additional related items to back up,
+                    the velero.io/exclude-from-backup label, and various other filters
+                    that happen as items are processed.
+                  type: integer
+              type: object
             startTimestamp:
               description: StartTimestamp records the time a backup was started. Separate
                 from CreationTimestamp, since that value changes on restores. The
@@ -364,7 +386,8 @@ spec:
               nullable: true
               type: array
             version:
-              description: Version is the backup format version.
+              description: 'Version is the backup format major version. Deprecated:
+                Please see FormatVersion'
               type: integer
             volumeSnapshotsAttempted:
               description: VolumeSnapshotsAttempted is the total number of attempted

--- a/deploy/olm-catalog/konveyor-operator/latest/backupstoragelocation.crd.yaml
+++ b/deploy/olm-catalog/konveyor-operator/latest/backupstoragelocation.crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (unknown)
+    controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: backupstoragelocations.velero.io
 spec:
@@ -58,6 +58,11 @@ spec:
               properties:
                 bucket:
                   description: Bucket is the bucket to use for object storage.
+                  type: string
+                caCert:
+                  description: CACert defines a CA bundle to use when verifying TLS
+                    connections to the provider.
+                  format: byte
                   type: string
                 prefix:
                   description: Prefix is the path inside a bucket to use for Velero

--- a/deploy/olm-catalog/konveyor-operator/latest/deletebackuprequest.crd.yaml
+++ b/deploy/olm-catalog/konveyor-operator/latest/deletebackuprequest.crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (unknown)
+    controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: deletebackuprequests.velero.io
 spec:

--- a/deploy/olm-catalog/konveyor-operator/latest/downloadrequest.crd.yaml
+++ b/deploy/olm-catalog/konveyor-operator/latest/downloadrequest.crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (unknown)
+    controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: downloadrequests.velero.io
 spec:

--- a/deploy/olm-catalog/konveyor-operator/latest/podvolumebackup.crd.yaml
+++ b/deploy/olm-catalog/konveyor-operator/latest/podvolumebackup.crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (unknown)
+    controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: podvolumebackups.velero.io
 spec:

--- a/deploy/olm-catalog/konveyor-operator/latest/podvolumerestore.crd.yaml
+++ b/deploy/olm-catalog/konveyor-operator/latest/podvolumerestore.crd.yaml
@@ -1,8 +1,10 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (unknown)
+    controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: podvolumerestores.velero.io
 spec:

--- a/deploy/olm-catalog/konveyor-operator/latest/resticrepository.crd.yaml
+++ b/deploy/olm-catalog/konveyor-operator/latest/resticrepository.crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (unknown)
+    controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: resticrepositories.velero.io
 spec:

--- a/deploy/olm-catalog/konveyor-operator/latest/restore.crd.yaml
+++ b/deploy/olm-catalog/konveyor-operator/latest/restore.crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (unknown)
+    controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: restores.velero.io
 spec:

--- a/deploy/olm-catalog/konveyor-operator/latest/schedule.crd.yaml
+++ b/deploy/olm-catalog/konveyor-operator/latest/schedule.crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (unknown)
+    controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: schedules.velero.io
 spec:

--- a/deploy/olm-catalog/konveyor-operator/latest/serverstatusrequest.crd.yaml
+++ b/deploy/olm-catalog/konveyor-operator/latest/serverstatusrequest.crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (unknown)
+    controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: serverstatusrequests.velero.io
 spec:

--- a/deploy/olm-catalog/konveyor-operator/latest/volumesnapshotlocation.crd.yaml
+++ b/deploy/olm-catalog/konveyor-operator/latest/volumesnapshotlocation.crd.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (unknown)
+    controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: volumesnapshotlocations.velero.io
 spec:

--- a/roles/migrationcontroller/templates/velero_supporting.yml.j2
+++ b/roles/migrationcontroller/templates/velero_supporting.yml.j2
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (unknown)
+    controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: backups.velero.io
 spec:
@@ -340,6 +340,10 @@ spec:
               format: date-time
               nullable: true
               type: string
+            formatVersion:
+              description: FormatVersion is the backup format version, including major,
+                minor, and patch version.
+              type: string
             phase:
               description: Phase is the current state of the Backup.
               enum:
@@ -351,6 +355,24 @@ spec:
               - Failed
               - Deleting
               type: string
+            progress:
+              description: Progress contains information about the backup's execution
+                progress. Note that this information is best-effort only -- if Velero
+                fails to update it during a backup for any reason, it may be inaccurate/stale.
+              nullable: true
+              properties:
+                itemsBackedUp:
+                  description: ItemsBackedUp is the number of items that have actually
+                    been written to the backup tarball so far.
+                  type: integer
+                totalItems:
+                  description: TotalItems is the total number of items to be backed
+                    up. This number may change throughout the execution of the backup
+                    due to plugins that return additional related items to back up,
+                    the velero.io/exclude-from-backup label, and various other filters
+                    that happen as items are processed.
+                  type: integer
+              type: object
             startTimestamp:
               description: StartTimestamp records the time a backup was started. Separate
                 from CreationTimestamp, since that value changes on restores. The
@@ -366,7 +388,8 @@ spec:
               nullable: true
               type: array
             version:
-              description: Version is the backup format version.
+              description: 'Version is the backup format major version. Deprecated:
+                Please see FormatVersion'
               type: integer
             volumeSnapshotsAttempted:
               description: VolumeSnapshotsAttempted is the total number of attempted
@@ -400,7 +423,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (unknown)
+    controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: schedules.velero.io
 spec:
@@ -776,7 +799,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (unknown)
+    controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: restores.velero.io
 spec:
@@ -1052,7 +1075,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (unknown)
+    controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: downloadrequests.velero.io
 spec:
@@ -1147,7 +1170,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (unknown)
+    controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: deletebackuprequests.velero.io
 spec:
@@ -1221,7 +1244,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (unknown)
+    controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: podvolumebackups.velero.io
 spec:
@@ -1384,7 +1407,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (unknown)
+    controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: podvolumerestores.velero.io
 spec:
@@ -1545,7 +1568,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (unknown)
+    controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: resticrepositories.velero.io
 spec:
@@ -1635,7 +1658,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (unknown)
+    controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: backupstoragelocations.velero.io
 spec:
@@ -1692,6 +1715,11 @@ spec:
               properties:
                 bucket:
                   description: Bucket is the bucket to use for object storage.
+                  type: string
+                caCert:
+                  description: CACert defines a CA bundle to use when verifying TLS
+                    connections to the provider.
+                  format: byte
                   type: string
                 prefix:
                   description: Prefix is the path inside a bucket to use for Velero
@@ -1757,7 +1785,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (unknown)
+    controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: volumesnapshotlocations.velero.io
 spec:
@@ -1832,7 +1860,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: (unknown)
+    controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: serverstatusrequests.velero.io
 spec:


### PR DESCRIPTION
**Description**
This PR includes the CRD changes required for the upgrade to velero 1.4.2. Merging needs to wait until 
https://github.com/konveyor/velero/pull/67 is merged first.

**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [X ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
* [ ] I updated downstream-prep.sh to only update the latest CSV patch version in the channel
