### PR TITLE
Clarify this operator migrates containers

### DIFF
--- a/deploy/olm-catalog/konveyor-operator/latest/konveyor-operator.v99.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/konveyor-operator/latest/konveyor-operator.v99.0.0.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     olm.skipRange: '>=0.0.0 <99.0.0'
     capabilities: Seamless Upgrades
-    description: Facilitates migration of workloads from OpenShift 3.x to OpenShift 4.x
+    description: Facilitates migration of container workloads from OpenShift 3.x to OpenShift 4.x
     categories: 'OpenShift Optional'
     containerImage: quay.io/konveyor/mig-operator-container:latest
     createdAt: 2019-07-25T10:21:00Z
@@ -204,7 +204,7 @@ spec:
     image: quay.io/konveyor/registry:latest
   - name: hook_runner
     image: quay.io/konveyor/hook-runner:latest
-  displayName: Konveyor Operator
+  displayName: Konveyor Operator for Containers
   description: |
     The Konveyor Operator enables installation of the application migration tool components.
 


### PR DESCRIPTION
**Description**
This changes the displayName to `Konveyor Operator for Containers` and changes the description to  `Facilitates migration of container workloads from OpenShift 3.x to OpenShift 4.x` to match the MTV operator.

![image](https://user-images.githubusercontent.com/1850500/90808742-7f0eed80-e2ee-11ea-89a3-bbeef907819f.png)


**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
* [ ] I updated downstream-prep.sh to only update the latest CSV patch version in the channel
