### PR TITLE
Fix latest due to operator sdk changes

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -16,6 +16,7 @@ COPY build/entrypoint /usr/local/bin/entrypoint
 USER 1001
 
 COPY build/requirements.yml ${HOME}/requirements.yml
+RUN ansible-galaxy collection install operator_sdk.util
 RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \
  && chmod -R ug+rwx ${HOME}/.ansible
 

--- a/roles/migrationcontroller/tasks/main.yml
+++ b/roles/migrationcontroller/tasks/main.yml
@@ -21,8 +21,8 @@
       operator_sdk.util.k8s_status:
         api_version: migration.openshift.io/v1alpha1
         kind: MigrationController
-        name: "{{ meta.name }}"
-        namespace: "{{ meta.namespace }}"
+        name: "{{ ansible_operator_meta.name }}"
+        namespace: "{{ ansible_operator_meta.namespace }}"
         force: true
         conditions: []
         status:
@@ -358,8 +358,8 @@
         operator_sdk.util.k8s_status:
           api_version: migration.openshift.io/v1alpha1
           kind: MigrationController
-          name: "{{ meta.name }}"
-          namespace: "{{ meta.namespace }}"
+          name: "{{ ansible_operator_meta.name }}"
+          namespace: "{{ ansible_operator_meta.namespace }}"
           conditions:
             - type: Critical
               status: True
@@ -374,8 +374,8 @@
         operator_sdk.util.k8s_status:
           api_version: migration.openshift.io/v1alpha1
           kind: MigrationController
-          name: "{{ meta.name }}"
-          namespace: "{{ meta.namespace }}"
+          name: "{{ ansible_operator_meta.name }}"
+          namespace: "{{ ansible_operator_meta.namespace }}"
           conditions:
             - type: Critical
               status: True
@@ -579,8 +579,8 @@
   - operator_sdk.util.k8s_status:
       api_version: migration.openshift.io/v1alpha1
       kind: MigrationController
-      name: "{{ meta.name }}"
-      namespace: "{{ meta.namespace }}"
+      name: "{{ ansible_operator_meta.name }}"
+      namespace: "{{ ansible_operator_meta.namespace }}"
       status:
         phase: Reconciled
     when: olm_managed and reconciled
@@ -588,8 +588,8 @@
   - operator_sdk.util.k8s_status:
       api_version: migration.openshift.io/v1alpha1
       kind: MigrationController
-      name: "{{ meta.name }}"
-      namespace: "{{ meta.namespace }}"
+      name: "{{ ansible_operator_meta.name }}"
+      namespace: "{{ ansible_operator_meta.namespace }}"
       status:
         phase: Failed
     when: olm_managed and not reconciled
@@ -608,8 +608,8 @@
     - operator_sdk.util.k8s_status:
         api_version: migration.openshift.io/v1alpha1
         kind: MigrationController
-        name: "{{ meta.name }}"
-        namespace: "{{ meta.namespace }}"
+        name: "{{ ansible_operator_meta.name }}"
+        namespace: "{{ ansible_operator_meta.namespace }}"
         status:
           phase: Failed
       when: item.type == 'Critical'

--- a/roles/migrationcontroller/templates/migration-controller.yml.j2
+++ b/roles/migrationcontroller/templates/migration-controller.yml.j2
@@ -1,7 +1,7 @@
 apiVersion: migration.openshift.io/v1alpha1
 kind: MigrationController
 metadata:
-  name: "{{ meta.name }}"
-  namespace: "{{ meta.namespace }}"
+  name: "{{ ansible_operator_meta.name }}"
+  namespace: "{{ ansible_operator_meta.namespace }}"
 spec:
   version: "1.0 (OLM)"


### PR DESCRIPTION
**Description**
This will fix latest which is broken right now. There will be a follow up to revert these name changes in the downstream-prep.sh script in the mtc-rename branch where there are a bunch of related downstream-prep changes happening.

**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
* [ ] I updated downstream-prep.sh to only update the latest CSV patch version in the channel
