### PR TITLE
Add watch verb on all resources for mig-controller SA

### DIFF
--- a/deploy/olm-catalog/konveyor-operator/latest/konveyor-operator.v99.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/konveyor-operator/latest/konveyor-operator.v99.0.0.clusterserviceversion.yaml
@@ -601,6 +601,7 @@ spec:
           verbs:
           - list
           - update
+          - watch
           - delete
           - deletecollection
         - apiGroups:

--- a/roles/migrationcontroller/templates/mig_rbac.yml.j2
+++ b/roles/migrationcontroller/templates/mig_rbac.yml.j2
@@ -207,6 +207,7 @@ rules:
   verbs:
   - list
   - delete
+  - watch
   - update
   - deletecollection
 - apiGroups:


### PR DESCRIPTION
**Description**
Closes issue #407 

I have verified that these changes resolve the watch RBAC errors when running migrations with cached client in mig-controller.

**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [x] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
* [ ] I updated downstream-prep.sh to only update the latest CSV patch version in the channel
