### PR TITLE
Add updated CRDs with printer columns

### DIFF
--- a/deploy/olm-catalog/konveyor-operator/latest/migration_v1alpha1_miganalytic.yaml
+++ b/deploy/olm-catalog/konveyor-operator/latest/migration_v1alpha1_miganalytic.yaml
@@ -6,6 +6,31 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: miganalytics.migration.openshift.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: Ready
+    type: string
+  - JSONPath: .spec.migPlanRef.name
+    name: Plan
+    type: string
+  - JSONPath: .status.analytics.percentComplete
+    name: Progress
+    type: string
+  - JSONPath: .status.analytics.k8sResourceTotal
+    name: Resources
+    type: string
+  - JSONPath: .status.analytics.imageCount
+    name: Images
+    type: string
+  - JSONPath: .status.analytics.imageSizeTotal
+    name: ImageSize
+    type: string
+  - JSONPath: .status.analytics.pvCount
+    name: PVs
+    type: string
+  - JSONPath: .status.analytics.pvCapacity
+    name: PVCapacity
+    type: string
   group: migration.openshift.io
   names:
     kind: MigAnalytic

--- a/deploy/olm-catalog/konveyor-operator/latest/migration_v1alpha1_migcluster.yaml
+++ b/deploy/olm-catalog/konveyor-operator/latest/migration_v1alpha1_migcluster.yaml
@@ -6,6 +6,16 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: migclusters.migration.openshift.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: Ready
+    type: string
+  - JSONPath: .spec.url
+    name: URL
+    type: string
+  - JSONPath: .spec.isHostCluster
+    name: Host
+    type: boolean
   group: migration.openshift.io
   names:
     kind: MigCluster

--- a/deploy/olm-catalog/konveyor-operator/latest/migration_v1alpha1_mighook.yaml
+++ b/deploy/olm-catalog/konveyor-operator/latest/migration_v1alpha1_mighook.yaml
@@ -6,6 +6,16 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: mighooks.migration.openshift.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: Ready
+    type: string
+  - JSONPath: .spec.image
+    name: Image
+    type: string
+  - JSONPath: .spec.targetCluster
+    name: TargetCluster
+    type: string
   group: migration.openshift.io
   names:
     kind: MigHook

--- a/deploy/olm-catalog/konveyor-operator/latest/migration_v1alpha1_migmigration.yaml
+++ b/deploy/olm-catalog/konveyor-operator/latest/migration_v1alpha1_migmigration.yaml
@@ -6,6 +6,22 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: migmigrations.migration.openshift.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: Ready
+    type: string
+  - JSONPath: .spec.migPlanRef.name
+    name: Plan
+    type: string
+  - JSONPath: .spec.stage
+    name: Stage
+    type: string
+  - JSONPath: .status.itinerary
+    name: Itinerary
+    type: string
+  - JSONPath: .status.phase
+    name: Phase
+    type: string
   group: migration.openshift.io
   names:
     kind: MigMigration
@@ -49,7 +65,7 @@ spec:
               items:
                 type: string
               type: array
-            itenerary:
+            itinerary:
               type: string
             observedDigest:
               type: string

--- a/deploy/olm-catalog/konveyor-operator/latest/migration_v1alpha1_migplan.yaml
+++ b/deploy/olm-catalog/konveyor-operator/latest/migration_v1alpha1_migplan.yaml
@@ -6,6 +6,19 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: migplans.migration.openshift.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: Ready
+    type: string
+  - JSONPath: .spec.srcMigClusterRef.name
+    name: Source
+    type: string
+  - JSONPath: .spec.destMigClusterRef.name
+    name: Target
+    type: string
+  - JSONPath: .spec.migStorageRef.name
+    name: Storage
+    type: string
   group: migration.openshift.io
   names:
     kind: MigPlan

--- a/deploy/olm-catalog/konveyor-operator/latest/migration_v1alpha1_migstorage.yaml
+++ b/deploy/olm-catalog/konveyor-operator/latest/migration_v1alpha1_migstorage.yaml
@@ -6,6 +6,16 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: migstorages.migration.openshift.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: Ready
+    type: string
+  - JSONPath: .spec.backupStorageProvider
+    name: BackupStorageProvider
+    type: string
+  - JSONPath: .spec.volumeSnapshotProvider
+    name: VolumeSnapshotProvider
+    type: string
   group: migration.openshift.io
   names:
     kind: MigStorage

--- a/roles/migrationcontroller/files/migration_v1alpha1_miganalytic.yaml
+++ b/roles/migrationcontroller/files/migration_v1alpha1_miganalytic.yaml
@@ -6,6 +6,31 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: miganalytics.migration.openshift.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: Ready
+    type: string
+  - JSONPath: .spec.migPlanRef.name
+    name: Plan
+    type: string
+  - JSONPath: .status.analytics.percentComplete
+    name: Progress
+    type: string
+  - JSONPath: .status.analytics.k8sResourceTotal
+    name: Resources
+    type: string
+  - JSONPath: .status.analytics.imageCount
+    name: Images
+    type: string
+  - JSONPath: .status.analytics.imageSizeTotal
+    name: ImageSize
+    type: string
+  - JSONPath: .status.analytics.pvCount
+    name: PVs
+    type: string
+  - JSONPath: .status.analytics.pvCapacity
+    name: PVCapacity
+    type: string
   group: migration.openshift.io
   names:
     kind: MigAnalytic

--- a/roles/migrationcontroller/files/migration_v1alpha1_migcluster.yaml
+++ b/roles/migrationcontroller/files/migration_v1alpha1_migcluster.yaml
@@ -6,6 +6,16 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: migclusters.migration.openshift.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: Ready
+    type: string
+  - JSONPath: .spec.url
+    name: URL
+    type: string
+  - JSONPath: .spec.isHostCluster
+    name: Host
+    type: boolean
   group: migration.openshift.io
   names:
     kind: MigCluster

--- a/roles/migrationcontroller/files/migration_v1alpha1_mighook.yaml
+++ b/roles/migrationcontroller/files/migration_v1alpha1_mighook.yaml
@@ -6,6 +6,16 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: mighooks.migration.openshift.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: Ready
+    type: string
+  - JSONPath: .spec.image
+    name: Image
+    type: string
+  - JSONPath: .spec.targetCluster
+    name: TargetCluster
+    type: string
   group: migration.openshift.io
   names:
     kind: MigHook

--- a/roles/migrationcontroller/files/migration_v1alpha1_migmigration.yaml
+++ b/roles/migrationcontroller/files/migration_v1alpha1_migmigration.yaml
@@ -6,6 +6,22 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: migmigrations.migration.openshift.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: Ready
+    type: string
+  - JSONPath: .spec.migPlanRef.name
+    name: Plan
+    type: string
+  - JSONPath: .spec.stage
+    name: Stage
+    type: string
+  - JSONPath: .status.itinerary
+    name: Itinerary
+    type: string
+  - JSONPath: .status.phase
+    name: Phase
+    type: string
   group: migration.openshift.io
   names:
     kind: MigMigration
@@ -49,7 +65,7 @@ spec:
               items:
                 type: string
               type: array
-            itenerary:
+            itinerary:
               type: string
             observedDigest:
               type: string

--- a/roles/migrationcontroller/files/migration_v1alpha1_migplan.yaml
+++ b/roles/migrationcontroller/files/migration_v1alpha1_migplan.yaml
@@ -6,6 +6,19 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: migplans.migration.openshift.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: Ready
+    type: string
+  - JSONPath: .spec.srcMigClusterRef.name
+    name: Source
+    type: string
+  - JSONPath: .spec.destMigClusterRef.name
+    name: Target
+    type: string
+  - JSONPath: .spec.migStorageRef.name
+    name: Storage
+    type: string
   group: migration.openshift.io
   names:
     kind: MigPlan

--- a/roles/migrationcontroller/files/migration_v1alpha1_migstorage.yaml
+++ b/roles/migrationcontroller/files/migration_v1alpha1_migstorage.yaml
@@ -6,6 +6,16 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: migstorages.migration.openshift.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: Ready
+    type: string
+  - JSONPath: .spec.backupStorageProvider
+    name: BackupStorageProvider
+    type: string
+  - JSONPath: .spec.volumeSnapshotProvider
+    name: VolumeSnapshotProvider
+    type: string
   group: migration.openshift.io
   names:
     kind: MigStorage


### PR DESCRIPTION
**Description**

- Adds printer column CRD changes to latest OLM catalog files
- Adds printer column CRD changes to roles/files dir

**Merge with**: https://github.com/konveyor/mig-controller/pull/643
**Issue Link**: https://github.com/konveyor/mig-controller/issues/599

**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [x] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
* [ ] I updated downstream-prep.sh to only update the latest CSV patch version in the channel
