### PR TITLE
fix OCP3 permissions and entrypoint

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -23,3 +23,5 @@ RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \
 COPY watches.yaml ${HOME}/watches.yaml
 
 COPY roles/ ${HOME}/roles/
+
+ENTRYPOINT /usr/local/bin/entrypoint

--- a/build/entrypoint
+++ b/build/entrypoint
@@ -17,4 +17,4 @@ if [ x"$USER_ID" != x"0" -a x"$USER_ID" != x"1001" ]; then
     export LD_PRELOAD
 fi
 
-exec ${OPERATOR} exec-entrypoint ansible --watches-file=/opt/ansible/watches.yaml $@
+/tini -- /usr/local/bin/ansible-operator run --watches-file=./watches.yaml

--- a/deploy/non-olm/latest/operator.yml
+++ b/deploy/non-olm/latest/operator.yml
@@ -111,6 +111,7 @@ rules:
   - events
   - configmaps
   - secrets
+  - serviceaccounts
   verbs:
   - '*'
 - apiGroups:
@@ -194,6 +195,49 @@ rules:
   - migration.openshift.io
   resources:
   - migclusters
+  verbs:
+  - '*'
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - infrastructures
+  - clusterversions
+  verbs:
+  - get
+- apiGroups:
+  - rbac.authorization.k8s.io
+  - security.openshift.io
+  - build.openshift.io
+  - migration.openshift.io
+  - velero.io
+  - packages.operators.coreos.com
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - get
+  - watch
+  - list
+  - update
+  - patch
+  - create
+  - delete
+  - assign
+  - deletecollection
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  - pods/log
+  verbs:
+  - '*'
+- nonResourceURLs:
+  - '*'
   verbs:
   - '*'
 ---

--- a/deploy/olm-catalog/konveyor-operator/latest/konveyor-operator.v99.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/konveyor-operator/latest/konveyor-operator.v99.0.0.clusterserviceversion.yaml
@@ -322,6 +322,7 @@ spec:
           - events
           - configmaps
           - secrets
+          - serviceaccounts
           verbs:
           - '*'
         - apiGroups:
@@ -412,6 +413,49 @@ spec:
           - migration.openshift.io
           resources:
           - migclusters
+          verbs:
+          - '*'
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - infrastructures
+          - clusterversions
+          verbs:
+          - get
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          - security.openshift.io
+          - build.openshift.io
+          - migration.openshift.io
+          - velero.io
+          - packages.operators.coreos.com
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - '*'
+          resources:
+          - '*'
+          verbs:
+          - get
+          - watch
+          - list
+          - update
+          - patch
+          - create
+          - delete
+          - assign
+          - deletecollection
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          - pods/log
+          verbs:
+          - '*'
+        - nonResourceURLs:
+          - '*'
           verbs:
           - '*'
       - serviceAccountName: migration-controller


### PR DESCRIPTION
**Description**
The operator will not deploy properly on OCP3 after we took away cluster-admin. This is because we need a number of permissions in to deploy the rbac rules that OLM would normally do for us. In addition we need permissions in order to assign them so a number of permissions the operator doesn't actually require have been added. 

The entrypoint has also changed which broke us on OCP3 because we need to run with nss_wrapper in order to get the ansible user mapped to the random UID/GID.

**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [X] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
* [ ] I updated downstream-prep.sh to only update the latest CSV patch version in the channel
