### PR TITLE
use infrastructure resource to get cluster URL

### DIFF
--- a/roles/migrationcontroller/tasks/main.yml
+++ b/roles/migrationcontroller/tasks/main.yml
@@ -68,32 +68,34 @@
   #It also lets us generate the cluster API endpoint URL on Openshift 4.
   - name: Get cluster config
     k8s_facts:
-      api_version: v1
-      kind: ConfigMap
-      name: cluster-config-v1
-      namespace: kube-system
-    register: cluster_configmap
+      api_version: config.openshift.io/v1
+      kind: ClusterVersion
+      name: version
+    register: cluster_version
 
-  - when: migration_ui and cluster_configmap.resources|length > 0
+  - name: Get the infrastructure
+    k8s_facts:
+      api_version: config.openshift.io/v1
+      kind: Infrastructure
+      name: cluster
+    register: infrastructures
+    ignore_errors: yes
+
+  - when: migration_ui and cluster_version.resources|length > 0
     block:
     - set_fact:
-        cluster_config_data: "{{ cluster_configmap.resources[0].data | regex_replace('install-config', 'install_config') }}"
-
-    - set_fact:
-        cluster_config: "{{ cluster_config_data.install_config | from_yaml }}"
-
-    - set_fact:
-        mig_ui_cluster_api_endpoint: "https://api.{{ cluster_config.metadata.name }}.{{ cluster_config.baseDomain }}:6443"
+        mig_ui_cluster_api_endpoint: "{{ infrastructures.resources[0].status.apiServerURL }}"
+      when: infrastructures is defined and infrastructures.get('resources', [{}])[0].get('status'. {}).get('apiServerURL', '') != ''
 
   - set_fact:
       restic_pv_host_path: /var/lib/origin/openshift.local.volumes/pods
-    when: cluster_configmap.resources|length == 0
+    when: infrastructures is not defined or infrastructures.resources|length == 0
 
   # This is only here to ease testing with openshift 3 dev environments
   - set_fact:
       restic_pv_host_path: /tmp/openshift.local.clusterup/openshift.local.volumes/pods
     when:
-    - cluster_configmap.resources|length == 0
+    - infrastructures.resources|length == 0
     - origin_three_dev is defined and origin_three_dev
 
   - when: migration_velero
@@ -294,7 +296,7 @@
         state: "{{ ui_state }}"
         definition: "{{ lookup('template', 'ui-oauthsecret.yml.j2') }}"
 
-    - when: cluster_configmap.resources|length > 0
+    - when: cluster_version.resources|length > 0
       block:
       - name: Retrieve apiserver config definition
         k8s_facts:


### PR DESCRIPTION
**Description**


**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
* [ ] I updated downstream-prep.sh to only update the latest CSV patch version in the channel
