### PR TITLE
Update Cluster, Plan, Storage CRD to include "refresh" spec field. Move StorageClasses cache to MigPlan.

### DIFF
--- a/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_migcluster.yaml
+++ b/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_migcluster.yaml
@@ -56,21 +56,6 @@ spec:
               type: boolean
             serviceAccountSecretRef:
               type: object
-            storageClasses:
-              items:
-                properties:
-                  accessModes:
-                    items:
-                      type: string
-                    type: array
-                  default:
-                    type: boolean
-                  name:
-                    type: string
-                  provisioner:
-                    type: string
-                type: object
-              type: array
             url:
               type: string
           required:

--- a/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_migcluster.yaml
+++ b/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_migcluster.yaml
@@ -50,6 +50,8 @@ spec:
               type: boolean
             isHostCluster:
               type: boolean
+            refresh:
+              type: boolean
             restartRestic:
               type: boolean
             serviceAccountSecretRef:

--- a/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_migplan.yaml
+++ b/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_migplan.yaml
@@ -133,6 +133,21 @@ spec:
           type: object
         status:
           properties:
+            destStorageClasses:
+              items:
+                properties:
+                  accessModes:
+                    items:
+                      type: string
+                    type: array
+                  default:
+                    type: boolean
+                  name:
+                    type: string
+                  provisioner:
+                    type: string
+                type: object
+              type: array
             excludedResources:
               items:
                 type: string
@@ -164,6 +179,21 @@ spec:
               type: array
             observedDigest:
               type: string
+            srcStorageClasses:
+              items:
+                properties:
+                  accessModes:
+                    items:
+                      type: string
+                    type: array
+                  default:
+                    type: boolean
+                  name:
+                    type: string
+                  provisioner:
+                    type: string
+                type: object
+              type: array
           type: object
   version: v1alpha1
 status:

--- a/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_migplan.yaml
+++ b/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_migplan.yaml
@@ -126,6 +126,8 @@ spec:
                 - selection
                 type: object
               type: array
+            refresh:
+              type: boolean
             srcMigClusterRef:
               type: object
           type: object

--- a/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_migstorage.yaml
+++ b/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_migstorage.yaml
@@ -75,6 +75,8 @@ spec:
               type: object
             backupStorageProvider:
               type: string
+            refresh:
+              type: boolean
             volumeSnapshotConfig:
               properties:
                 awsRegion:

--- a/roles/migrationcontroller/files/migration_v1alpha1_migcluster.yaml
+++ b/roles/migrationcontroller/files/migration_v1alpha1_migcluster.yaml
@@ -56,21 +56,6 @@ spec:
               type: boolean
             serviceAccountSecretRef:
               type: object
-            storageClasses:
-              items:
-                properties:
-                  accessModes:
-                    items:
-                      type: string
-                    type: array
-                  default:
-                    type: boolean
-                  name:
-                    type: string
-                  provisioner:
-                    type: string
-                type: object
-              type: array
             url:
               type: string
           required:

--- a/roles/migrationcontroller/files/migration_v1alpha1_migcluster.yaml
+++ b/roles/migrationcontroller/files/migration_v1alpha1_migcluster.yaml
@@ -50,6 +50,8 @@ spec:
               type: boolean
             isHostCluster:
               type: boolean
+            refresh:
+              type: boolean
             restartRestic:
               type: boolean
             serviceAccountSecretRef:

--- a/roles/migrationcontroller/files/migration_v1alpha1_migplan.yaml
+++ b/roles/migrationcontroller/files/migration_v1alpha1_migplan.yaml
@@ -133,6 +133,21 @@ spec:
           type: object
         status:
           properties:
+            destStorageClasses:
+              items:
+                properties:
+                  accessModes:
+                    items:
+                      type: string
+                    type: array
+                  default:
+                    type: boolean
+                  name:
+                    type: string
+                  provisioner:
+                    type: string
+                type: object
+              type: array
             excludedResources:
               items:
                 type: string
@@ -164,6 +179,21 @@ spec:
               type: array
             observedDigest:
               type: string
+            srcStorageClasses:
+              items:
+                properties:
+                  accessModes:
+                    items:
+                      type: string
+                    type: array
+                  default:
+                    type: boolean
+                  name:
+                    type: string
+                  provisioner:
+                    type: string
+                type: object
+              type: array
           type: object
   version: v1alpha1
 status:

--- a/roles/migrationcontroller/files/migration_v1alpha1_migplan.yaml
+++ b/roles/migrationcontroller/files/migration_v1alpha1_migplan.yaml
@@ -126,6 +126,8 @@ spec:
                 - selection
                 type: object
               type: array
+            refresh:
+              type: boolean
             srcMigClusterRef:
               type: object
           type: object

--- a/roles/migrationcontroller/files/migration_v1alpha1_migstorage.yaml
+++ b/roles/migrationcontroller/files/migration_v1alpha1_migstorage.yaml
@@ -75,6 +75,8 @@ spec:
               type: object
             backupStorageProvider:
               type: string
+            refresh:
+              type: boolean
             volumeSnapshotConfig:
               properties:
                 awsRegion:


### PR DESCRIPTION
**Description**

- Adds "refresh" field to plan, cluster, storage CR spec to trigger manual update.
- Moves StorageClasses cache from MigClusters to MigPlan since data is only using in MigPlan reconcile (PV discovery)

Related to https://github.com/konveyor/mig-controller/pull/651 **(Remove all remote watches)**

**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [x] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
