### PR TITLE
Added switch to enable/disable memory profiling of mig-controller

### DIFF
--- a/roles/migrationcontroller/defaults/main.yml
+++ b/roles/migrationcontroller/defaults/main.yml
@@ -35,6 +35,7 @@ mig_controller_requests_cpu: "100m"
 mig_controller_requests_memory: "350Mi"
 mig_controller_version: "{{ snapshot_tag | default(lookup( 'env', 'MIG_CONTROLLER_TAG')) }}"
 mig_controller_image_fqin: "{{ mig_controller_image }}:{{ mig_controller_version }}"
+mig_controller_mem_profile_enabled: true
 discovery_volume_path: "/var/cache/discovery"
 mig_pv_limit: "100"
 mig_pod_limit: "100"

--- a/roles/migrationcontroller/templates/controller.yml.j2
+++ b/roles/migrationcontroller/templates/controller.yml.j2
@@ -92,6 +92,14 @@ spec:
         - name: HTTP_PROXY
           value: {{ http_proxy }}
 {% endif %}
+{% if not mig_controller_mem_profile_enabled %}
+        - name: GODEBUG
+          value: "memprofilerate=0,"
+{% endif %}
+{% if mig_controller_mem_profile_enabled %}
+        - name: GODEBUG
+          value: "memprofilerate=524288,"
+{% endif %}
 {% if https_proxy|length >0 %}
         - name: HTTPS_PROXY
           value: {{ https_proxy }}


### PR DESCRIPTION
**Description**
This PR adds a new configuration option in MigrationController CR that allows the user to enable / disable pprof memory profiling on mig-controller. Since the configuration is passed as an environment variable, the user has to delete existing migration-controller pod for new changes to take effect whenever they alter the value of variable `mig_controller_mem_profile_enabled`. It is enabled by default. 

Goes with : https://github.com/konveyor/mig-controller/pull/659

**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
