### PR TITLE
remove CAM, which is downstream and now called MTC

### DIFF
--- a/deploy/olm-catalog/konveyor-operator/latest/konveyor-operator.v99.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/konveyor-operator/latest/konveyor-operator.v99.0.0.clusterserviceversion.yaml
@@ -231,7 +231,7 @@ spec:
 
     * velero and restic, to back up data on the source cluster and restore it on the target cluster
     * mig-controller, to coordinate the backup and restore processes
-    * mig-ui, the CAM web console for managing migrations
+    * mig-ui, the web console for managing migrations
 
     If you experience any issues or have feature requests, please file an [issue](https://github.com/konveyor/mig-operator/issues)
 

--- a/deploy/olm-catalog/konveyor-operator/v1.3.0/konveyor-operator.v1.3.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/konveyor-operator/v1.3.0/konveyor-operator.v1.3.0.clusterserviceversion.yaml
@@ -230,7 +230,7 @@ spec:
 
     * velero and restic, to back up data on the source cluster and restore it on the target cluster
     * mig-controller, to coordinate the backup and restore processes
-    * mig-ui, the CAM web console for managing migrations
+    * mig-ui, the web console for managing migrations
 
     If you experience any issues or have feature requests, please file an [issue](https://github.com/konveyor/mig-operator/issues)
 


### PR DESCRIPTION
**Description**


**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
