### PR TITLE
Bug 1873641 - Allow user to supply custom supplemental groups for restic pods

### DIFF
--- a/roles/migrationcontroller/defaults/main.yml
+++ b/roles/migrationcontroller/defaults/main.yml
@@ -65,6 +65,7 @@ registry: "{{ lookup( 'env', 'REGISTRY') }}"
 project: "{{ lookup( 'env', 'PROJECT') }}"
 restic_pv_host_path: /var/lib/kubelet/pods
 restic_timeout: 1h
+restic_supplemental_groups: []
 ui_state: absent
 velero_aws_secret_name: cloud-credentials
 velero_gcp_secret_name: gcp-cloud-credentials

--- a/roles/migrationcontroller/templates/velero.yml.j2
+++ b/roles/migrationcontroller/templates/velero.yml.j2
@@ -182,6 +182,7 @@ spec:
       serviceAccountName: velero
       securityContext:
         runAsUser: 0
+        supplementalGroups: {{ restic_supplemental_groups }}
       volumes:
         - name: {{ velero_aws_secret_name }}
           secret:


### PR DESCRIPTION
**Description**
Allows a user to set a new variable `restic_supplemental_groups` in the `migrationcontroller` resource which is a list:
```
  spec:
  ...
    restic_supplemental_groups:
    - 5555
    - 6666
```

Which adds it to the restic pods daemonset:
```
  securityContext:                                                                        
    runAsUser: 0                                                                                                                                                            
    supplementalGroups:    
    - 5555                                                                                                                                                                  
    - 6666   
```

Now in the pod:
```
[dymurray@pups mig-operator]$ oc exec -it restic-cm7qn bash
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl kubectl exec [POD] -- [COMMAND] instead.
[root@restic-cm7qn /]# id
uid=0(root) gid=0(root) groups=0(root),5555,6666
```
**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV


