### PR TITLE
Fixes 435 - Add customizable velero QPS/Burst with increased default

### DIFF
--- a/roles/migrationcontroller/defaults/main.yml
+++ b/roles/migrationcontroller/defaults/main.yml
@@ -96,6 +96,8 @@ velero_azure_plugin_repo: "{{ lookup( 'env', 'VELERO_AZURE_PLUGIN_REPO') }}"
 velero_azure_plugin_version: "{{ snapshot_tag | default(lookup( 'env', 'VELERO_AZURE_PLUGIN_TAG')) }}"
 velero_azure_plugin_fqin: "{{ velero_azure_plugin_image }}:{{ velero_azure_plugin_version }}"
 velero_state: absent
+velero_qps: 100
+velero_burst: 1000
 
 # MCG integration
 noobaa: false

--- a/roles/migrationcontroller/templates/velero.yml.j2
+++ b/roles/migrationcontroller/templates/velero.yml.j2
@@ -46,6 +46,10 @@ spec:
             - /velero
           args:
             - server
+            - --client-burst
+            - "{{ velero_burst }}"
+            - --client-qps
+            - "{{ velero_qps }}"
             - --restic-timeout
             - {{ restic_timeout }}
 {% if velero_debug %}


### PR DESCRIPTION
**Description**


**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
