### PR TITLE
[WIP] Revert "Bug 1844638: Add switch for controlling migration rollback"

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,47 +59,16 @@ The default limits are:
   - 100 Persistent Volumes per MigPlan
 
 Resource limits can be adjusted by configuring the MigrationController resource responsible for deploying mig-controller.
-
-```
-oc edit MigrationController -n openshift-migration
-```
-
 ```
   [...]
   migration_controller: true
   
-  # Resource limit configuration is loaded into mig-controller, and should be set on the
+  # This configuration is loaded into mig-controller, and should be set on the
   # cluster where `migration_controller: true`
   mig_pv_limit: 100
   mig_pod_limit: 100
   mig_namespace_limit: 10
   [...]
-```
-
-#### Adjusting Rollback on Migration Failure
-If an unexpected error causes a migration to fail, you can control migration behavior according to your needs.
-
-Automatic rollback is disabled by default, but can be enabled by configuring the MigrationController resource responsible for deploying mig-controller.
-
-```
-oc edit MigrationController -n openshift-migration
-```
-
-```
- [...]
- 
- # Rollback configuration is loaded into mig-controller, and should be set on the
- # cluster where `migration_controller: true`
- migration_controller: true
-
- # [Default] Setting 'mig_failure_rollback: false' leaves the partially migrated workloads 
- # in place on the target cluster.
- mig_failure_rollback: false
-
- # Setting 'mig_failure_rollback: true' removes the partially migrated workloads from the
- # target cluster and scales them back up on the source cluster.
- mig_failure_rollback: true
- [...]
 ```
 
 ## CORS (Cross-Origin Resource Sharing) Configuration

--- a/deploy/non-olm/latest/controller-4.yml
+++ b/deploy/non-olm/latest/controller-4.yml
@@ -14,8 +14,6 @@ spec:
   mig_pv_limit: 100
   mig_pod_limit: 100
   mig_namespace_limit: 10
-  
-  mig_failure_rollback: false
 
   #Uncomment the following line for OpenShift 4.1
   #deprecated_cors_configuration: true

--- a/deploy/non-olm/v1.2.2/controller-4.yml
+++ b/deploy/non-olm/v1.2.2/controller-4.yml
@@ -15,7 +15,5 @@ spec:
   mig_pod_limit: 100
   mig_namespace_limit: 10
 
-  mig_failure_rollback: false
-
   #Uncomment the following line for OpenShift 4.1
   #deprecated_cors_configuration: true

--- a/deploy/olm-catalog/konveyor-operator/latest/konveyor-operator.v99.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/konveyor-operator/latest/konveyor-operator.v99.0.0.clusterserviceversion.yaml
@@ -31,8 +31,7 @@ metadata:
               "restic_timeout": "1h",
               "mig_pv_limit": "100",
               "mig_pod_limit": "100",
-              "mig_namespace_limit": "10",
-              "mig_failure_rollback": false
+              "mig_namespace_limit": "10"
             }
         },
         {

--- a/deploy/olm-catalog/konveyor-operator/v1.2.2/konveyor-operator.v1.2.2.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/konveyor-operator/v1.2.2/konveyor-operator.v1.2.2.clusterserviceversion.yaml
@@ -31,8 +31,7 @@ metadata:
               "restic_timeout": "1h",
               "mig_pv_limit": "100",
               "mig_pod_limit": "100",
-              "mig_namespace_limit": "10",
-              "mig_failure_rollback": false
+              "mig_namespace_limit": "10"
             }
         },
         {

--- a/roles/migrationcontroller/defaults/main.yml
+++ b/roles/migrationcontroller/defaults/main.yml
@@ -39,7 +39,6 @@ discovery_volume_path: "/var/cache/discovery"
 mig_pv_limit: "100"
 mig_pod_limit: "100"
 mig_namespace_limit: "10"
-mig_failure_rollback: false
 mig_namespace: "{{ lookup( 'env', 'WATCH_NAMESPACE') | default('openshift-migration') }}"
 mig_ui_cluster_api_endpoint: ""
 mig_ui_configmap_data: ""

--- a/roles/migrationcontroller/templates/controller.yml.j2
+++ b/roles/migrationcontroller/templates/controller.yml.j2
@@ -34,7 +34,6 @@ data:
   NAMESPACE_LIMIT: "{{ mig_namespace_limit }}"
   CORS_ALLOWED_ORIGINS: {{ cors_origins | join(' ') }}
   WORKING_DIR: {{ discovery_volume_path }}
-  FAILURE_ROLLBACK: "{{ mig_failure_rollback }}"
 ---
 {% if lookup('k8s', cluster_info='version').kubernetes.minor|replace('+', '')|int < 9 %}
 apiVersion: apps/v1beta1
@@ -68,7 +67,6 @@ spec:
         | join(mig_pod_limit | string)
         | join(mig_namespace_limit | string)
         | join(discovery_volume_path | string)
-        | join(mig_failure_rollback | string)
         | hash('sha1') }}"
     spec:
       serviceAccountName: migration-controller


### PR DESCRIPTION
In order to support MigMigration spec-based rollback control, it is needed to remove current Settings-based solution for automatic rollback.

Reverts konveyor/mig-operator#370

Related to https://github.com/konveyor/mig-controller/issues/663