### PR TITLE
Fix 3.7 upgrades

### DIFF
--- a/roles/migrationcontroller/templates/velero.yml.j2
+++ b/roles/migrationcontroller/templates/velero.yml.j2
@@ -29,6 +29,12 @@ spec:
       labels:
         component: velero
       annotations:
+{% if lookup('k8s', cluster_info='version').kubernetes.minor|replace('+', '')|int < 9 %}
+        pod.alpha.kubernetes.io/init-containers: >-
+          [{"name":"velero-plugin","image":"{{ velero_plugin_fqin }}","resources":{},"volumeMounts":[{"name":"plugins","mountPath":"/target"}],"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"{{ image_pull_policy }}"},{"name":"velero-plugin-for-aws","image":"{{ velero_aws_plugin_fqin }}","resources":{},"volumeMounts":[{"name":"plugins","mountPath":"/target"}],"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"{{ image_pull_policy }}"},{"name":"velero-plugin-for-gcp","image":"{{ velero_gcp_plugin_fqin }}","resources":{},"volumeMounts":[{"name":"plugins","mountPath":"/target"}],"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"{{ image_pull_policy }}"},{"name":"velero-plugin-for-microsoft-azure","image":"{{ velero_azure_plugin_fqin }}","resources":{},"volumeMounts":[{"name":"plugins","mountPath":"/target"}],"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"{{ image_pull_policy }}"},{"name":"setup-certificate-secret","image":"{{ velero_image_fqin }}","command":["sh","-ec","cp -f /etc/ssl/certs/* /certs/; ln -sf /credentials/ca_bundle.pem /certs/ca_bundle.pem;"],"resources":{},"volumeMounts":[{"name":"certs","mountPath":"/certs"},{"name":"cloud-credentials","mountPath":"/credentials"}],"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"{{ image_pull_policy }}"}]
+        pod.beta.kubernetes.io/init-containers: >-
+          [{"name":"velero-plugin","image":"{{ velero_plugin_fqin }}","resources":{},"volumeMounts":[{"name":"plugins","mountPath":"/target"}],"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"{{ image_pull_policy }}"},{"name":"velero-plugin-for-aws","image":"{{ velero_aws_plugin_fqin }}","resources":{},"volumeMounts":[{"name":"plugins","mountPath":"/target"}],"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"{{ image_pull_policy }}"},{"name":"velero-plugin-for-gcp","image":"{{ velero_gcp_plugin_fqin }}","resources":{},"volumeMounts":[{"name":"plugins","mountPath":"/target"}],"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"{{ image_pull_policy }}"},{"name":"velero-plugin-for-microsoft-azure","image":"{{ velero_azure_plugin_fqin }}","resources":{},"volumeMounts":[{"name":"plugins","mountPath":"/target"}],"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"{{ image_pull_policy }}"},{"name":"setup-certificate-secret","image":"{{ velero_image_fqin }}","command":["sh","-ec","cp -f /etc/ssl/certs/* /certs/; ln -sf /credentials/ca_bundle.pem /certs/ca_bundle.pem;"],"resources":{},"volumeMounts":[{"name":"certs","mountPath":"/certs"},{"name":"cloud-credentials","mountPath":"/credentials"}],"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"{{ image_pull_policy }}"}]
+{% endif %}
         prometheus.io/scrape: "true"
         prometheus.io/port: "8085"
         prometheus.io/path: "/metrics"
@@ -180,6 +186,13 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+{% if lookup('k8s', cluster_info='version').kubernetes.minor|replace('+', '')|int < 9 %}
+      annotations:
+        pod.alpha.kubernetes.io/init-containers: >-
+          [{"name":"setup-certificate-secret","image":"{{ velero_image_fqin }}","command":["sh","-ec","cp /etc/ssl/certs/* /certs/; ln -sf /credentials/ca_bundle.pem /certs/ca_bundle.pem;"],"resources":{},"volumeMounts":[{"name":"certs","mountPath":"/certs"},{"name":"cloud-credentials","mountPath":"/credentials"}],"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"{{ image_pull_policy }}"}]
+        pod.beta.kubernetes.io/init-containers: >-
+          [{"name":"setup-certificate-secret","image":"{{ velero_image_fqin }}","command":["sh","-ec","cp /etc/ssl/certs/* /certs/; ln -sf /credentials/ca_bundle.pem /certs/ca_bundle.pem;"],"resources":{},"volumeMounts":[{"name":"certs","mountPath":"/certs"},{"name":"cloud-credentials","mountPath":"/credentials"}],"terminationMessagePath":"/dev/termination-log","terminationMessagePolicy":"File","imagePullPolicy":"{{ image_pull_policy }}"}]
+{% endif %}
       labels:
         name: restic
     spec:


### PR DESCRIPTION
**Description**
https://github.com/kubernetes/kubernetes/issues/47264
"Correct. Pre-1.8, the information is duplicated in two places in the object, with the annotation taking precedence. 1.8+, only the field is honored. You should set the field for forward compatibility, and set the annotation if you want your changes to be effective against a pre-1.8 server."

The workaround duplicates the configuration into the annotations for 3.7.

**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
