### PR TITLE
Rollback on demand update

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,32 +141,6 @@ spec:
 
 Setting for the max allowable number of resources in a Migration Plan. The default limits serve as a recommendation to break up large scale migrations into several smaller Migration Plans.
 
-#### Rollback on Migration Failure
-
-```
-spec:
-  mig_failure_rollback: false
-```
-
-The default _rollback on failure_ setting is false.
-
-```
- [...]
- 
- # Rollback configuration is loaded into mig-controller, and should be set on the
- # cluster where `migration_controller: true`
- migration_controller: true
-
- # [Default] Setting 'mig_failure_rollback: false' leaves the partially migrated workloads 
- # in place on the target cluster.
- mig_failure_rollback: false
-
- # Setting 'mig_failure_rollback: true' removes the partially migrated workloads from the
- # target cluster and scales them back up on the source cluster.
- mig_failure_rollback: true
- [...]
-```
-
 ## CORS (Cross-Origin Resource Sharing) Configuration
 
 You must follow the [CORs configuration steps](./docs/cors.md) _only if_:

--- a/deploy/non-olm/latest/controller-4.yml
+++ b/deploy/non-olm/latest/controller-4.yml
@@ -14,8 +14,6 @@ spec:
   mig_pv_limit: 100
   mig_pod_limit: 100
   mig_namespace_limit: 10
-  
-  mig_failure_rollback: false
 
   #Uncomment the following line for OpenShift 4.1
   #deprecated_cors_configuration: true

--- a/deploy/olm-catalog/bundle/manifests/konveyor-operator.v99.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/bundle/manifests/konveyor-operator.v99.0.0.clusterserviceversion.yaml
@@ -31,8 +31,7 @@ metadata:
               "restic_timeout": "1h",
               "mig_pv_limit": "100",
               "mig_pod_limit": "100",
-              "mig_namespace_limit": "10",
-              "mig_failure_rollback": false
+              "mig_namespace_limit": "10"
             }
         },
         {

--- a/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_migmigration.yaml
+++ b/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_migmigration.yaml
@@ -16,6 +16,9 @@ spec:
   - JSONPath: .spec.stage
     name: Stage
     type: string
+  - JSONPath: .spec.rollback
+    name: Rollback
+    type: string
   - JSONPath: .status.itinerary
     name: Itinerary
     type: string
@@ -54,6 +57,8 @@ spec:
             migPlanRef:
               type: object
             quiescePods:
+              type: boolean
+            rollback:
               type: boolean
             stage:
               type: boolean

--- a/roles/migrationcontroller/defaults/main.yml
+++ b/roles/migrationcontroller/defaults/main.yml
@@ -40,7 +40,6 @@ discovery_volume_path: "/var/cache/discovery"
 mig_pv_limit: "100"
 mig_pod_limit: "100"
 mig_namespace_limit: "10"
-mig_failure_rollback: false
 mig_namespace: "{{ lookup( 'env', 'WATCH_NAMESPACE') | default('openshift-migration') }}"
 mig_ui_cluster_api_endpoint: ""
 mig_ui_configmap_data: ""

--- a/roles/migrationcontroller/files/migration_v1alpha1_migmigration.yaml
+++ b/roles/migrationcontroller/files/migration_v1alpha1_migmigration.yaml
@@ -16,6 +16,9 @@ spec:
   - JSONPath: .spec.stage
     name: Stage
     type: string
+  - JSONPath: .spec.rollback
+    name: Rollback
+    type: string
   - JSONPath: .status.itinerary
     name: Itinerary
     type: string
@@ -54,6 +57,8 @@ spec:
             migPlanRef:
               type: object
             quiescePods:
+              type: boolean
+            rollback:
               type: boolean
             stage:
               type: boolean

--- a/roles/migrationcontroller/templates/controller.yml.j2
+++ b/roles/migrationcontroller/templates/controller.yml.j2
@@ -34,7 +34,6 @@ data:
   NAMESPACE_LIMIT: "{{ mig_namespace_limit }}"
   CORS_ALLOWED_ORIGINS: {{ cors_origins | join(' ') }}
   WORKING_DIR: {{ discovery_volume_path }}
-  FAILURE_ROLLBACK: "{{ mig_failure_rollback }}"
 ---
 {% if lookup('k8s', cluster_info='version').kubernetes.minor|replace('+', '')|int < 9 %}
 apiVersion: apps/v1beta1
@@ -68,7 +67,6 @@ spec:
         | join(mig_pod_limit | string)
         | join(mig_namespace_limit | string)
         | join(discovery_volume_path | string)
-        | join(mig_failure_rollback | string)
         | hash('sha1') }}"
     spec:
       serviceAccountName: migration-controller


### PR DESCRIPTION
Updating code related to migration rollback functionality.

1. This removes older rollback on failure logic
2. Update migmigration CR (adds rollback field, for new releases, not backport)

Related to https://github.com/konveyor/mig-controller/pull/677 and https://github.com/konveyor/mig-controller/issues/663

Replaces https://github.com/konveyor/mig-operator/pull/455
