### PR TITLE
Direct volume migration RBAC+CRD additions

### DIFF
--- a/deploy/olm-catalog/bundle/manifests/konveyor-operator.v99.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/bundle/manifests/konveyor-operator.v99.0.0.clusterserviceversion.yaml
@@ -600,6 +600,7 @@ spec:
           - delete
         - apiGroups:
           - apps.openshift.io
+          - route.openshift.io
           resources:
           - '*'
           verbs:

--- a/deploy/olm-catalog/bundle/manifests/konveyor-operator.v99.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/bundle/manifests/konveyor-operator.v99.0.0.clusterserviceversion.yaml
@@ -599,6 +599,14 @@ spec:
           - patch
           - delete
         - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+          resourceNames:
+          - privileged
+        - apiGroups:
           - apps.openshift.io
           - route.openshift.io
           resources:

--- a/deploy/olm-catalog/bundle/manifests/konveyor-operator.v99.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/bundle/manifests/konveyor-operator.v99.0.0.clusterserviceversion.yaml
@@ -161,6 +161,15 @@ metadata:
         },
         {
             "apiVersion": "migration.openshift.io/v1alpha1",
+            "kind": "DirectVolumeMigration",
+            "metadata": {
+              "name": "direct",
+              "namespace": "openshift-migration"
+            },
+            "spec": {}
+        },
+        {
+            "apiVersion": "migration.openshift.io/v1alpha1",
             "kind": "MigPlan",
             "metadata": {
               "name": "migplan",
@@ -842,6 +851,11 @@ spec:
       kind: MigCluster
       displayName: MigCluster
       description: A cluster defined for migration
+    - name: directvolumemigrations.migration.openshift.ioa
+      version: v1alpha1
+      kind: DirectVolumeMigration
+      displayName: DirectVolumeMigration
+      description: A request to migrate a set of PVCs directly to a target
     - name: migmigrations.migration.openshift.io
       version: v1alpha1
       kind: MigMigration

--- a/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_directvolumemigration.yaml
+++ b/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_directvolumemigration.yaml
@@ -1,0 +1,70 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: directvolumemigrations.migration.openshift.io
+spec:
+  group: migration.openshift.io
+  names:
+    kind: DirectVolumeMigration
+    plural: directvolumemigrations
+    shortNames:
+    - dvm
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            createDestinationNamespaces:
+              type: boolean
+            destMigClusterRef:
+              type: object
+            persistentVolumeClaims:
+              items:
+                type: object
+              type: array
+            srcMigClusterRef:
+              type: object
+            storageClassMapping:
+              type: object
+          type: object
+        status:
+          properties:
+            errors:
+              items:
+                type: string
+              type: array
+            itinerary:
+              type: string
+            observedDigest:
+              type: string
+            phase:
+              type: string
+            startTimestamp:
+              format: date-time
+              type: string
+          required:
+          - observedDigest
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/molecule/test-local/converge.yml
+++ b/molecule/test-local/converge.yml
@@ -77,6 +77,7 @@
       with_items:
       - "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_miganalytic.yaml"
       - "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_migcluster.yaml"
+      - "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_directvolumemigration.yaml"
       - "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_mighook.yaml"
       - "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_migmigration.yaml"
       - "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_migplan.yaml"

--- a/roles/migrationcontroller/files/migration_v1alpha1_directvolumemigration.yaml
+++ b/roles/migrationcontroller/files/migration_v1alpha1_directvolumemigration.yaml
@@ -1,0 +1,70 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: directvolumemigrations.migration.openshift.io
+spec:
+  group: migration.openshift.io
+  names:
+    kind: DirectVolumeMigration
+    plural: directvolumemigrations
+    shortNames:
+    - dvm
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            createDestinationNamespaces:
+              type: boolean
+            destMigClusterRef:
+              type: object
+            persistentVolumeClaims:
+              items:
+                type: object
+              type: array
+            srcMigClusterRef:
+              type: object
+            storageClassMapping:
+              type: object
+          type: object
+        status:
+          properties:
+            errors:
+              items:
+                type: string
+              type: array
+            itinerary:
+              type: string
+            observedDigest:
+              type: string
+            phase:
+              type: string
+            startTimestamp:
+              format: date-time
+              type: string
+          required:
+          - observedDigest
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/roles/migrationcontroller/tasks/main.yml
+++ b/roles/migrationcontroller/tasks/main.yml
@@ -206,6 +206,7 @@
     - "migration_v1alpha1_mighook.yaml"
     - "migration_v1alpha1_migstorage.yaml"
     - "migration_v1alpha1_miganalytic.yaml"
+    - "migration_v1alpha1_directvolumemigration.yaml"
     when: not olm_managed
 
   - name: "Set up mig controller RBAC"

--- a/roles/migrationcontroller/templates/mig_rbac.yml.j2
+++ b/roles/migrationcontroller/templates/mig_rbac.yml.j2
@@ -55,10 +55,19 @@ rules:
 - apiGroups:
   - migration.openshift.io
   - velero.io
+  - route.openshift.io
   resources:
   - '*'
   verbs:
   - '*'
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+  resourceNames:
+  - privileged
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
**Description**
These are the needed RBAC changes to support direct PV migration.

Added access to route.openshift.io API group and added use of privileged SCC for rsync transfer pods.

**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [X] I modified operand permissions in the OLM CSV **and** ansible role
* [x] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
