### PR TITLE
add new CRDs for direct image migration

### DIFF
--- a/deploy/olm-catalog/bundle/manifests/konveyor-operator.v99.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/bundle/manifests/konveyor-operator.v99.0.0.clusterserviceversion.yaml
@@ -135,6 +135,24 @@ metadata:
         },
         {
             "apiVersion": "migration.openshift.io/v1alpha1",
+            "kind": "DirectImageMigration",
+            "metadata": {
+              "name": "directimagemigration",
+              "namespace": "openshift-migration"
+            },
+            "spec": {}
+        },
+        {
+            "apiVersion": "migration.openshift.io/v1alpha1",
+            "kind": "DirectImageStreamMigration",
+            "metadata": {
+              "name": "directimagestreammigration",
+              "namespace": "openshift-migration"
+            },
+            "spec": {}
+        },
+        {
+            "apiVersion": "migration.openshift.io/v1alpha1",
             "kind": "MigAnalytic",
             "metadata": {
               "name": "host",
@@ -823,6 +841,16 @@ spec:
       kind: DownloadRequest
       displayName: DownloadRequest
       description: A download request for velero
+    - name: directimagemigrations.migration.openshift.io
+      version: v1alpha1
+      kind: DirectImageMigration
+      displayName: DirectImageMigration
+      description: a request to migrate local images from a set of namespaces directly to a target
+    - name: directimagestreammigrations.migration.openshift.io
+      version: v1alpha1
+      kind: DirectImageStreamMigration
+      displayName: DirectImageStreamMigration
+      description: a request to migrate local images from a single imagestream directly to a target
     - name: miganalytics.migration.openshift.io
       version: v1alpha1
       kind: MigAnalytic

--- a/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_directimagemigration.yaml
+++ b/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_directimagemigration.yaml
@@ -4,25 +4,14 @@ metadata:
   creationTimestamp: null
   labels:
     controller-tools.k8s.io: "1.0"
-  name: migclusters.migration.openshift.io
+  name: directimagemigrations.migration.openshift.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.conditions[?(@.type=='Ready')].status
-    name: Ready
-    type: string
-  - JSONPath: .spec.url
-    name: URL
-    type: string
-  - JSONPath: .spec.isHostCluster
-    name: Host
-    type: boolean
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
   group: migration.openshift.io
   names:
-    kind: MigCluster
-    plural: migclusters
+    kind: DirectImageMigration
+    plural: directimagemigrations
+    shortNames:
+    - dim
   scope: Namespaced
   validation:
     openAPIV3Schema:
@@ -41,31 +30,42 @@ spec:
           type: object
         spec:
           properties:
-            azureResourceGroup:
-              type: string
-            caBundle:
-              format: byte
-              type: string
-            exposedRegistryPath:
-              type: string
-            insecure:
-              type: boolean
-            isHostCluster:
-              type: boolean
-            refresh:
-              type: boolean
-            restartRestic:
-              type: boolean
-            serviceAccountSecretRef:
+            destMigClusterRef:
               type: object
-            url:
-              type: string
-          required:
-          - isHostCluster
+            namespaces:
+              items:
+                type: string
+              type: array
+            srcMigClusterRef:
+              type: object
           type: object
         status:
           properties:
+            errors:
+              items:
+                type: string
+              type: array
+            imageStreams:
+              items:
+                properties:
+                  destNamespace:
+                    type: string
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                  notFound:
+                    type: boolean
+                type: object
+              type: array
+            itinerary:
+              type: string
             observedDigest:
+              type: string
+            phase:
+              type: string
+            startTimestamp:
+              format: date-time
               type: string
           type: object
   version: v1alpha1

--- a/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_directimagestreammigration.yaml
+++ b/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_directimagestreammigration.yaml
@@ -4,25 +4,14 @@ metadata:
   creationTimestamp: null
   labels:
     controller-tools.k8s.io: "1.0"
-  name: migclusters.migration.openshift.io
+  name: directimagestreammigrations.migration.openshift.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.conditions[?(@.type=='Ready')].status
-    name: Ready
-    type: string
-  - JSONPath: .spec.url
-    name: URL
-    type: string
-  - JSONPath: .spec.isHostCluster
-    name: Host
-    type: boolean
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
   group: migration.openshift.io
   names:
-    kind: MigCluster
-    plural: migclusters
+    kind: DirectImageStreamMigration
+    plural: directimagestreammigrations
+    shortNames:
+    - dism
   scope: Namespaced
   validation:
     openAPIV3Schema:
@@ -41,31 +30,29 @@ spec:
           type: object
         spec:
           properties:
-            azureResourceGroup:
-              type: string
-            caBundle:
-              format: byte
-              type: string
-            exposedRegistryPath:
-              type: string
-            insecure:
-              type: boolean
-            isHostCluster:
-              type: boolean
-            refresh:
-              type: boolean
-            restartRestic:
-              type: boolean
-            serviceAccountSecretRef:
+            destMigClusterRef:
               type: object
-            url:
+            destNamespace:
               type: string
-          required:
-          - isHostCluster
+            imageStreamRef:
+              type: object
+            srcMigClusterRef:
+              type: object
           type: object
         status:
           properties:
+            errors:
+              items:
+                type: string
+              type: array
+            itinerary:
+              type: string
             observedDigest:
+              type: string
+            phase:
+              type: string
+            startTimestamp:
+              format: date-time
               type: string
           type: object
   version: v1alpha1

--- a/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_migcluster.yaml
+++ b/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_migcluster.yaml
@@ -46,6 +46,8 @@ spec:
             caBundle:
               format: byte
               type: string
+            exposedRegistryPath:
+              type: string
             insecure:
               type: boolean
             isHostCluster:

--- a/molecule/test-local/converge.yml
+++ b/molecule/test-local/converge.yml
@@ -75,6 +75,8 @@
       k8s:
         definition: "{{ lookup('file', item) }}"
       with_items:
+      - "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_directimagemigration.yaml"
+      - "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_directimagestreammigration.yaml"
       - "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_miganalytic.yaml"
       - "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_migcluster.yaml"
       - "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_mighook.yaml"

--- a/roles/migrationcontroller/files/migration_v1alpha1_directimagemigration.yaml
+++ b/roles/migrationcontroller/files/migration_v1alpha1_directimagemigration.yaml
@@ -4,25 +4,14 @@ metadata:
   creationTimestamp: null
   labels:
     controller-tools.k8s.io: "1.0"
-  name: migclusters.migration.openshift.io
+  name: directimagemigrations.migration.openshift.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.conditions[?(@.type=='Ready')].status
-    name: Ready
-    type: string
-  - JSONPath: .spec.url
-    name: URL
-    type: string
-  - JSONPath: .spec.isHostCluster
-    name: Host
-    type: boolean
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
   group: migration.openshift.io
   names:
-    kind: MigCluster
-    plural: migclusters
+    kind: DirectImageMigration
+    plural: directimagemigrations
+    shortNames:
+    - dim
   scope: Namespaced
   validation:
     openAPIV3Schema:
@@ -41,31 +30,42 @@ spec:
           type: object
         spec:
           properties:
-            azureResourceGroup:
-              type: string
-            caBundle:
-              format: byte
-              type: string
-            exposedRegistryPath:
-              type: string
-            insecure:
-              type: boolean
-            isHostCluster:
-              type: boolean
-            refresh:
-              type: boolean
-            restartRestic:
-              type: boolean
-            serviceAccountSecretRef:
+            destMigClusterRef:
               type: object
-            url:
-              type: string
-          required:
-          - isHostCluster
+            namespaces:
+              items:
+                type: string
+              type: array
+            srcMigClusterRef:
+              type: object
           type: object
         status:
           properties:
+            errors:
+              items:
+                type: string
+              type: array
+            imageStreams:
+              items:
+                properties:
+                  destNamespace:
+                    type: string
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                  notFound:
+                    type: boolean
+                type: object
+              type: array
+            itinerary:
+              type: string
             observedDigest:
+              type: string
+            phase:
+              type: string
+            startTimestamp:
+              format: date-time
               type: string
           type: object
   version: v1alpha1

--- a/roles/migrationcontroller/files/migration_v1alpha1_directimagestreammigration.yaml
+++ b/roles/migrationcontroller/files/migration_v1alpha1_directimagestreammigration.yaml
@@ -4,25 +4,14 @@ metadata:
   creationTimestamp: null
   labels:
     controller-tools.k8s.io: "1.0"
-  name: migclusters.migration.openshift.io
+  name: directimagestreammigrations.migration.openshift.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.conditions[?(@.type=='Ready')].status
-    name: Ready
-    type: string
-  - JSONPath: .spec.url
-    name: URL
-    type: string
-  - JSONPath: .spec.isHostCluster
-    name: Host
-    type: boolean
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
   group: migration.openshift.io
   names:
-    kind: MigCluster
-    plural: migclusters
+    kind: DirectImageStreamMigration
+    plural: directimagestreammigrations
+    shortNames:
+    - dism
   scope: Namespaced
   validation:
     openAPIV3Schema:
@@ -41,31 +30,29 @@ spec:
           type: object
         spec:
           properties:
-            azureResourceGroup:
-              type: string
-            caBundle:
-              format: byte
-              type: string
-            exposedRegistryPath:
-              type: string
-            insecure:
-              type: boolean
-            isHostCluster:
-              type: boolean
-            refresh:
-              type: boolean
-            restartRestic:
-              type: boolean
-            serviceAccountSecretRef:
+            destMigClusterRef:
               type: object
-            url:
+            destNamespace:
               type: string
-          required:
-          - isHostCluster
+            imageStreamRef:
+              type: object
+            srcMigClusterRef:
+              type: object
           type: object
         status:
           properties:
+            errors:
+              items:
+                type: string
+              type: array
+            itinerary:
+              type: string
             observedDigest:
+              type: string
+            phase:
+              type: string
+            startTimestamp:
+              format: date-time
               type: string
           type: object
   version: v1alpha1

--- a/roles/migrationcontroller/tasks/main.yml
+++ b/roles/migrationcontroller/tasks/main.yml
@@ -200,6 +200,8 @@
       state: "present"
       src: "{{ role_path }}/files/{{ item }}"
     with_items:
+    - "migration_v1alpha1_directimagemigration.yaml"
+    - "migration_v1alpha1_directimagestreammigration.yaml"
     - "migration_v1alpha1_migcluster.yaml"
     - "migration_v1alpha1_migmigration.yaml"
     - "migration_v1alpha1_migplan.yaml"


### PR DESCRIPTION
**Description**
This adds new CRDs for direct image migration, and modifies MigCluster to add a new Spec field

**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [X] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV

These changes should be pushed along with https://github.com/konveyor/mig-controller/pull/710