### PR TITLE
DVM : fix missing permissions on Routes for Operator's Cluster Role

### DIFF
--- a/deploy/non-olm/latest/operator.yml
+++ b/deploy/non-olm/latest/operator.yml
@@ -211,6 +211,7 @@ rules:
   - migration.openshift.io
   - velero.io
   - packages.operators.coreos.com
+  - route.openshift.io
   resources:
   - '*'
   verbs:


### PR DESCRIPTION
**Description**


**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [x] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
