### PR TITLE
Add discovery api URL override var

### DIFF
--- a/roles/migrationcontroller/tasks/main.yml
+++ b/roles/migrationcontroller/tasks/main.yml
@@ -463,6 +463,11 @@
     - set_fact:
         discovery_api_url: "https://{{discovery_route.resources[0].spec.host}}"
 
+    - when: discovery_api_url_override
+      name: Set override discovery_api_url for local mig-controller
+      set_fact:
+        discovery_api_url: "{{ discovery_api_url_override }}"
+
     - name: Check if migration ui configmap exists already so we don't update it
       k8s_facts:
         api_version: v1


### PR DESCRIPTION
**Description**
Merge with https://github.com/konveyor/mig-controller/pull/754

Part of the solution for enabling mig-ui to work with a locally running mig-controller
https://github.com/konveyor/mig-controller/issues/728

I haven't been able to test this yet. podman is failing trying to run one of the commands in the doc.

**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
