### PR TITLE
Remove build requirement for podman

### DIFF
--- a/docs/hacking.md
+++ b/docs/hacking.md
@@ -85,7 +85,6 @@ The tooling and steps for pushing metadata depend on the OpenShift version.
 #### Prerequisities
 
 - Install `opm` from [operator-registry](https://github.com/operator-framework/operator-registry)
-- Install `podman` from your package manager
 
 #### Build bundle and index images, update CatalogSource 
 
@@ -108,8 +107,8 @@ The tooling and steps for pushing metadata depend on the OpenShift version.
 3. Build and push the _index image_
 
    ```   
-   opm index add -p docker --bundles quay.io/$ORG/mig-operator-bundle:$TAG --tag quay.io/$ORG/mig-operator-index:$TAG
-   podman push quay.io/$ORG/mig-operator-index:$TAG
+   opm index add --container-tool docker --bundles quay.io/$ORG/mig-operator-bundle:$TAG --tag quay.io/$ORG/mig-operator-index:$TAG
+   docker push quay.io/$ORG/mig-operator-index:$TAG
    ```
    *Note*: visit quay.io and make `mig-operator-index` public before continuing
 
@@ -145,7 +144,6 @@ The tooling and steps for pushing metadata depend on the OpenShift version.
 #### Prerequisities
 
  - Install `opm` from [operator-registry](https://github.com/operator-framework/operator-registry)
- - Install `podman` from your package manager
  - Install `operator-courier`
 
     ```
@@ -181,7 +179,7 @@ The tooling and steps for pushing metadata depend on the OpenShift version.
 3. Use `opm` to export metadata from your index image in _appregistry format_
 
    ```
-   opm index export -c podman -i quay.io/$ORG/mig-operator-index:$TAG -o mtc-operator
+   opm index export --container-tool docker -i quay.io/$ORG/mig-operator-index:$TAG -o mtc-operator
    ```
    *Note*: This will produce a directory called `downloaded` with _appregistry format_ metadata.
 


### PR DESCRIPTION
**Description**

I propose we make our build instructions platform agnostic where possible. The `opm` commands used in hacking.md can be tweaked with `--container-tool docker|podman` to the user's liking. 

I expanded the flag from `-c` to `--container-tool` in the suggested commands to make it clearer how to change this option if the user wants to, but for the sake of not making the user install 2 container tools when only 1 is needed for this build, I suggest we standardize on docker and mention podman can be used as a substitute. 

I think podman users will know that they can use podman instead if we make the flags clear and call it out in the doc

