### PR TITLE
CRD changes for direct image/volume migration integration

### DIFF
--- a/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_directvolumemigration.yaml
+++ b/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_directvolumemigration.yaml
@@ -32,15 +32,25 @@ spec:
           properties:
             createDestinationNamespaces:
               type: boolean
+            deleteProgressReportingCRs:
+              type: boolean
             destMigClusterRef:
               type: object
             persistentVolumeClaims:
               items:
+                properties:
+                  targetAccessModes:
+                    items:
+                      type: string
+                    type: array
+                  targetStorageClass:
+                    type: string
+                required:
+                - targetStorageClass
+                - targetAccessModes
                 type: object
               type: array
             srcMigClusterRef:
-              type: object
-            storageClassMapping:
               type: object
           type: object
         status:
@@ -49,15 +59,32 @@ spec:
               items:
                 type: string
               type: array
+            failedPods:
+              items:
+                type: object
+              type: array
             itinerary:
               type: string
             observedDigest:
               type: string
             phase:
               type: string
+            runningPods:
+              items:
+                properties:
+                  lastObservedProgressPercent:
+                    type: string
+                  lastObservedTransferRate:
+                    type: string
+                type: object
+              type: array
             startTimestamp:
               format: date-time
               type: string
+            successfulPods:
+              items:
+                type: object
+              type: array
           required:
           - observedDigest
           type: object

--- a/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_migcluster.yaml
+++ b/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_migcluster.yaml
@@ -67,6 +67,8 @@ spec:
           properties:
             observedDigest:
               type: string
+            registryPath:
+              type: string
           type: object
   version: v1alpha1
 status:

--- a/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_migplan.yaml
+++ b/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_migplan.yaml
@@ -66,6 +66,10 @@ spec:
                 - serviceAccount
                 type: object
               type: array
+            indirectImageMigration:
+              type: boolean
+            indirectVolumeMigration:
+              type: boolean
             migStorageRef:
               type: object
             namespaces:

--- a/roles/migrationcontroller/files/migration_v1alpha1_directvolumemigration.yaml
+++ b/roles/migrationcontroller/files/migration_v1alpha1_directvolumemigration.yaml
@@ -32,15 +32,25 @@ spec:
           properties:
             createDestinationNamespaces:
               type: boolean
+            deleteProgressReportingCRs:
+              type: boolean
             destMigClusterRef:
               type: object
             persistentVolumeClaims:
               items:
+                properties:
+                  targetAccessModes:
+                    items:
+                      type: string
+                    type: array
+                  targetStorageClass:
+                    type: string
+                required:
+                - targetStorageClass
+                - targetAccessModes
                 type: object
               type: array
             srcMigClusterRef:
-              type: object
-            storageClassMapping:
               type: object
           type: object
         status:
@@ -49,15 +59,32 @@ spec:
               items:
                 type: string
               type: array
+            failedPods:
+              items:
+                type: object
+              type: array
             itinerary:
               type: string
             observedDigest:
               type: string
             phase:
               type: string
+            runningPods:
+              items:
+                properties:
+                  lastObservedProgressPercent:
+                    type: string
+                  lastObservedTransferRate:
+                    type: string
+                type: object
+              type: array
             startTimestamp:
               format: date-time
               type: string
+            successfulPods:
+              items:
+                type: object
+              type: array
           required:
           - observedDigest
           type: object

--- a/roles/migrationcontroller/files/migration_v1alpha1_migcluster.yaml
+++ b/roles/migrationcontroller/files/migration_v1alpha1_migcluster.yaml
@@ -67,6 +67,8 @@ spec:
           properties:
             observedDigest:
               type: string
+            registryPath:
+              type: string
           type: object
   version: v1alpha1
 status:

--- a/roles/migrationcontroller/files/migration_v1alpha1_migplan.yaml
+++ b/roles/migrationcontroller/files/migration_v1alpha1_migplan.yaml
@@ -66,6 +66,10 @@ spec:
                 - serviceAccount
                 type: object
               type: array
+            indirectImageMigration:
+              type: boolean
+            indirectVolumeMigration:
+              type: boolean
             migStorageRef:
               type: object
             namespaces:


### PR DESCRIPTION
**Description**
CRD changes for integrating direct image/volume migration into migplan/migmigration.

This won't be ready to merge until we're ready to merge the direct-migration mig-controller topic branch

**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ X] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
