### PR TITLE
Add 'singular:' for dvm & dvmp

### DIFF
--- a/deploy/olm-catalog/bundle/manifests/konveyor-operator.v99.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/bundle/manifests/konveyor-operator.v99.0.0.clusterserviceversion.yaml
@@ -908,11 +908,6 @@ spec:
       kind: MigCluster
       displayName: MigCluster
       description: A cluster defined for migration
-    - name: directvolumemigrations.migration.openshift.io
-      version: v1alpha1
-      kind: DirectVolumeMigration
-      displayName: DirectVolumeMigration
-      description: A request to migrate a set of PVCs directly to a target
     - name: migmigrations.migration.openshift.io
       version: v1alpha1
       kind: MigMigration

--- a/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_directvolumemigration.yaml
+++ b/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_directvolumemigration.yaml
@@ -10,6 +10,7 @@ spec:
   names:
     kind: DirectVolumeMigration
     plural: directvolumemigrations
+    singular: directvolumemigration
     shortNames:
     - dvm
   scope: Namespaced

--- a/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_directvolumemigrationprogress.yaml
+++ b/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_directvolumemigrationprogress.yaml
@@ -10,6 +10,7 @@ spec:
   names:
     kind: DirectVolumeMigrationProgress
     plural: directvolumemigrationprogresses
+    singular: directvolumemigrationprogress
     shortNames:
     - dvmp
   scope: Namespaced


### PR DESCRIPTION
**Description**

* Add `singular:` for DVM & DVMP for successful CVP linting
* Remove duplicate DVM entry in deploy/olm-catalog/bundle/manifests/konveyor-operator.v99.0.0.clusterserviceversion.yaml

**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [X] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
