### PR TITLE
Revert "Add 'singular:' for dvm & dvmp (#510)"

### DIFF
--- a/deploy/olm-catalog/bundle/manifests/konveyor-operator.v99.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/bundle/manifests/konveyor-operator.v99.0.0.clusterserviceversion.yaml
@@ -908,6 +908,11 @@ spec:
       kind: MigCluster
       displayName: MigCluster
       description: A cluster defined for migration
+    - name: directvolumemigrations.migration.openshift.io
+      version: v1alpha1
+      kind: DirectVolumeMigration
+      displayName: DirectVolumeMigration
+      description: A request to migrate a set of PVCs directly to a target
     - name: migmigrations.migration.openshift.io
       version: v1alpha1
       kind: MigMigration

--- a/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_directvolumemigration.yaml
+++ b/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_directvolumemigration.yaml
@@ -10,7 +10,6 @@ spec:
   names:
     kind: DirectVolumeMigration
     plural: directvolumemigrations
-    singular: directvolumemigration
     shortNames:
     - dvm
   scope: Namespaced

--- a/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_directvolumemigrationprogress.yaml
+++ b/deploy/olm-catalog/bundle/manifests/migration_v1alpha1_directvolumemigrationprogress.yaml
@@ -10,7 +10,6 @@ spec:
   names:
     kind: DirectVolumeMigrationProgress
     plural: directvolumemigrationprogresses
-    singular: directvolumemigrationprogress
     shortNames:
     - dvmp
   scope: Namespaced


### PR DESCRIPTION
This reverts commit 3d4dd4295f8500c6b89e59589d4c0d3d46db37c7.

**Description**


**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
