### PR TITLE
fixed CRD for migmigration to make sure step started/completed appear

### DIFF
--- a/deploy/olm-catalog/bundle/manifests/migration.openshift.io_migmigrations.yaml
+++ b/deploy/olm-catalog/bundle/manifests/migration.openshift.io_migmigrations.yaml
@@ -184,6 +184,10 @@ spec:
               items:
                 description: Step defines a task in a step of migration
                 properties:
+                  completed:
+                    description: Completed timestamp.
+                    format: date-time
+                    type: string
                   failed:
                     type: boolean
                   message:
@@ -198,6 +202,10 @@ spec:
                     type: array
                   skipped:
                     type: boolean
+                  started:
+                    description: Started timestamp.
+                    format: date-time
+                    type: string
                 required:
                 - name
                 type: object

--- a/roles/migrationcontroller/files/migration.openshift.io_migmigrations.yaml
+++ b/roles/migrationcontroller/files/migration.openshift.io_migmigrations.yaml
@@ -184,6 +184,10 @@ spec:
               items:
                 description: Step defines a task in a step of migration
                 properties:
+                  completed:
+                    description: Completed timestamp.
+                    format: date-time
+                    type: string
                   failed:
                     type: boolean
                   message:
@@ -198,6 +202,10 @@ spec:
                     type: array
                   skipped:
                     type: boolean
+                  started:
+                    description: Started timestamp.
+                    format: date-time
+                    type: string
                 required:
                 - name
                 type: object


### PR DESCRIPTION
**Description**
CRD fix for https://github.com/konveyor/mig-controller/pull/856

**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ X] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
