### PR TITLE
fix a typo in dvmp CR for non-olm operator

### DIFF
--- a/roles/migrationcontroller/tasks/main.yml
+++ b/roles/migrationcontroller/tasks/main.yml
@@ -212,7 +212,7 @@
     - "migration.openshift.io_migstorages.yaml"
     - "migration.openshift.io_miganalytics.yaml"
     - "migration.openshift.io_directvolumemigrations.yaml"
-    - "migration.openshift.io_directvolumemigrationprogresss.yaml"
+    - "migration.openshift.io_directvolumemigrationprogresses.yaml"
     when: not olm_managed
 
   - name: "Set up mig controller RBAC"


### PR DESCRIPTION
**Description**
this fixes a typo for non-olm deployment of the operator

**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
