### PR TITLE
config map data to configure rsync client, transfer and stunnel pods

### DIFF
--- a/roles/migrationcontroller/defaults/main.yml
+++ b/roles/migrationcontroller/defaults/main.yml
@@ -28,6 +28,18 @@ rsync_transfer_image: "{{ registry }}/{{ project }}/{{ rsync_transfer_repo }}"
 rsync_transfer_repo: "{{ lookup( 'env', 'RSYNC_TRANSFER_REPO') }}"
 rsync_transfer_version: "{{ snapshot_tag | default(lookup( 'env', 'RSYNC_TRANSFER_TAG')) }}"
 rsync_transfer_image_fqin: "{{ rsync_transfer_image }}:{{ rsync_transfer_version }}"
+client_pod_cpu_limit: "1"
+client_pod_memory_limit: "1Gi"
+client_pod_cpu_request: "400m"
+client_pod_memory_request: "1Gi"
+stunnel_pod_cpu_limits: '1'
+stunnel_pod_cpu_requests: '400m'
+stunnel_pod_mem_limits: '1Gi'
+stunnel_pod_mem_requests: '1Gi'
+transfer_pod_cpu_limits: '1'
+transfer_pod_cpu_requests: '400m'
+transfer_pod_mem_limits: '1Gi'
+transfer_pod_mem_requests: '1Gi'
 hook_runner_image: "{{ registry }}/{{ project }}/{{ hook_runner_repo }}"
 hook_runner_repo: "{{ lookup( 'env', 'HOOK_RUNNER_REPO') }}"
 hook_runner_version: "{{ snapshot_tag | default(lookup( 'env', 'HOOK_RUNNER_TAG')) }}"

--- a/roles/migrationcontroller/templates/controller.yml.j2
+++ b/roles/migrationcontroller/templates/controller.yml.j2
@@ -34,6 +34,18 @@ data:
   NAMESPACE_LIMIT: "{{ mig_namespace_limit }}"
   CORS_ALLOWED_ORIGINS: {{ cors_origins | join(' ') }}
   WORKING_DIR: {{ discovery_volume_path }}
+  CLIENT_POD_CPU_LIMIT: "{{ client_pod_cpu_limit }}"
+  CLIENT_POD_MEMORY_LIMIT: "{{ client_pod_memory_limit }}"
+  CLIENT_POD_CPU_REQUEST: "{{ client_pod_cpu_request }}"
+  CLIENT_POD_MEMORY_REQUEST: "{{ client_pod_memory_request }}"
+  TRANSFER_POD_CPU_LIMIT: "{{ transfer_pod_cpu_limits }}"
+  TRANSFER_POD_MEMORY_LIMIT: "{{ transfer_pod_mem_limits }}"
+  TRANSFER_POD_CPU_REQUEST: "{{ transfer_pod_cpu_requests }}"
+  TRANSFER_POD_MEMORY_REQUEST: "{{ transfer_pod_mem_requests }}"
+  STUNNEL_POD_CPU_LIMIT: "{{ stunnel_pod_cpu_limits }}"
+  STUNNEL_POD_MEMORY_LIMIT: "{{ stunnel_pod_mem_limits }}"
+  STUNNEL_POD_CPU_REQUEST: "{{ stunnel_pod_cpu_requests }}"
+  STUNNEL_POD_MEMORY_REQUEST: "{{ stunnel_pod_mem_requests }}"
 ---
 {% if lookup('k8s', cluster_info='version').kubernetes.minor|replace('+', '')|int < 9 %}
 apiVersion: apps/v1beta1


### PR DESCRIPTION
**Description**
This PR request populates the `migration-controller` configMap to configure rsync client, rsync transfer, and stunnel pod's CPU and memory.

**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV

fixes https://github.com/konveyor/mig-controller/issues/863