### PR TITLE
Add rsync-transfer to v1.4.0 operator.yml

### DIFF
--- a/deploy/non-olm/v1.4.0/operator.yml
+++ b/deploy/non-olm/v1.4.0/operator.yml
@@ -308,6 +308,10 @@ spec:
           value: quay.io
         - name: PROJECT
           value: konveyor
+        - name: RSYNC_TRANSFER_REPO
+          value: rsync-transfer
+        - name: RSYNC_TRANSFER_TAG
+          value: release-1.4.0
         - name: HOOK_RUNNER_REPO
           value: hook-runner
         - name: HOOK_RUNNER_TAG


### PR DESCRIPTION
**Description**
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1910518

**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
