### PR TITLE
Add operator.yml and controller-3.yml to root of image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -12,6 +12,8 @@ RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.n
 
 RUN ln -s ${HOME}/.ansible /.ansible
 COPY build/entrypoint /usr/local/bin/entrypoint
+COPY deploy/non-olm/v1.4.0/operator.yml /operator.yml
+COPY deploy/non-olm/v1.4.0/controller-3.yml /controller-3.yml
 
 USER 1001
 


### PR DESCRIPTION
**Description**
This just copies the operator.yml and controller-3.yml in place as we do downstream so that it can be obtained in a similar manner. There is a separate PR to restructure the non-olm files in master that will cover this for future releases.

**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
