### PR TITLE
Document process to use sprint releases on 3.x

### DIFF
--- a/docs/releases.md
+++ b/docs/releases.md
@@ -44,3 +44,14 @@ spec:
   sourceType: grpc
   image: quay.io/konveyor/mig-operator-index:sprint-xxx.y
 ```
+
+Starting with sprint 195 to use OCP 3.x you can run the commands below. Ensure you replace xxx.y with the values corresponding to the release you wish to use.
+```
+export SPRINT=sprint-xxx.y
+podman cp $(podman create quay.io/konveyor/mig-operator-container:$SPRINT):/operator.yml ./
+podman cp $(podman create quay.io/konveyor/mig-operator-container:$SPRINT):/controller-3.yml ./
+sed -i "s/value: latest/value: $SPRINT/g" operator.yml
+oc create -f operator.yml
+```
+
+Modify settings in the controller-3.yml as desired and `oc create -f controller-3.yml` as you normally would.


### PR DESCRIPTION
**Description**
Document how to use sprint releases on 3.x

**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
