### PR TITLE
Add rsync environment variables to mtc controller

### DIFF
--- a/roles/migrationcontroller/templates/controller.yml.j2
+++ b/roles/migrationcontroller/templates/controller.yml.j2
@@ -46,6 +46,27 @@ data:
   STUNNEL_POD_MEMORY_LIMIT: "{{ stunnel_pod_mem_limits }}"
   STUNNEL_POD_CPU_REQUEST: "{{ stunnel_pod_cpu_requests }}"
   STUNNEL_POD_MEMORY_REQUEST: "{{ stunnel_pod_mem_requests }}"
+{% if rsync_opt_bwlimit is defined and rsync_opt_bwlimit|int > 0 %}
+  RSYNC_OPT_BWLIMIT: "{{ rsync_opt_bwlimit }}"
+{% endif %}
+{% if rsync_opt_partial is defined %}
+  RSYNC_OPT_PARTIAL: "{{ rsync_opt_partial }}"
+{% endif %}
+{% if rsync_opt_archive is defined %}
+  RSYNC_OPT_ARCHIVE: "{{ rsync_opt_archive }}"
+{% endif %}
+{% if rsync_opt_delete is defined %}
+  RSYNC_OPT_DELETE: "{{ rsync_opt_delete }}"
+{% endif %}
+{% if rsync_opt_hardlinks is defined %}
+  RSYNC_OPT_HARDLINKS: "{{ rsync_opt_hardlinks }}"
+{% endif %}
+{% if rsync_opt_info is defined %}
+  RSYNC_OPT_INFO: "{{ rsync_opt_info }}"
+{% endif %}
+{% if rsync_opt_extras is defined %}
+  RSYNC_OPT_EXTRAS: "{{ rsync_opt_extras }}"
+{% endif %}
 ---
 {% if lookup('k8s', cluster_info='version').kubernetes.minor|replace('+', '')|int < 9 %}
 apiVersion: apps/v1beta1


### PR DESCRIPTION
**Description**
Adds new environment variables in MTC container deployment to allow configuring Rsync flags. 

**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
