### PR TITLE
MIG-505: add privileged flag for rsync pods

### DIFF
--- a/deploy/olm-catalog/bundle/manifests/konveyor-operator.v99.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/bundle/manifests/konveyor-operator.v99.0.0.clusterserviceversion.yaml
@@ -650,6 +650,7 @@ spec:
           - use
           resourceNames:
           - privileged
+          - anyuid
         - apiGroups:
           - apps.openshift.io
           - route.openshift.io

--- a/molecule/test-local/converge.yml
+++ b/molecule/test-local/converge.yml
@@ -41,6 +41,7 @@
     pull_policy: Never
     custom_resource: "{{ lookup('file', '/'.join([deploy_dir, 'migration_v1alpha1_migration_cr.yaml'])) | from_yaml }}"
     mig_namespace: "{{ namespace }}"
+    migration_rsync_privileged: false
   tasks:
   - block:
     - name: Delete the Operator Deployment

--- a/roles/migrationcontroller/defaults/main.yml
+++ b/roles/migrationcontroller/defaults/main.yml
@@ -82,6 +82,7 @@ migration_stage_image: "{{ registry }}/{{ project }}/{{ velero_restic_restore_he
 migration_stage_repo: "{{ lookup( 'env', 'VELERO_RESTIC_RESTORE_HELPER_REPO') }}"
 migration_stage_version: "{{ snapshot_tag | default(lookup( 'env', 'VELERO_RESTIC_RESTORE_HELPER_TAG')) }}"
 migration_stage_image_fqin: "{{ migration_stage_image }}:{{ migration_stage_version }}"
+migration_rsync_privileged: false
 olm_managed: false
 registry: "{{ lookup( 'env', 'REGISTRY') }}"
 project: "{{ lookup( 'env', 'PROJECT') }}"

--- a/roles/migrationcontroller/templates/mig-cluster-config.yml.j2
+++ b/roles/migrationcontroller/templates/mig-cluster-config.yml.j2
@@ -11,3 +11,4 @@ data:
   STAGE_IMAGE: "{{ migration_stage_image_fqin }}"
   REGISTRY_IMAGE: "{{ migration_registry_image_fqin }}"
   RSYNC_TRANSFER_IMAGE: "{{ rsync_transfer_image_fqin }}"
+  RSYNC_PRIVILEGED: "{{ migration_rsync_privileged }}"

--- a/roles/migrationcontroller/templates/mig_rbac.yml.j2
+++ b/roles/migrationcontroller/templates/mig_rbac.yml.j2
@@ -68,7 +68,11 @@ rules:
   verbs:
   - use
   resourceNames:
+{% if migration_rsync_privileged %}
   - privileged
+{% else %}
+  - anyuid
+{% endif %}
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
**Description**


**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [x] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
