### PR TITLE
Bug 1859998: Propagate the disable_image_copy to the mig-controller.

### DIFF
--- a/roles/migrationcontroller/defaults/main.yml
+++ b/roles/migrationcontroller/defaults/main.yml
@@ -5,6 +5,7 @@ controller_state: absent
 deprecated_cors_configuration: false
 cors_origins: []
 disable_image_migration: false
+disable_image_copy: false
 disable_pv_migration: false
 excluded_resources:
   - imagetags

--- a/roles/migrationcontroller/templates/controller_config.yml.j2
+++ b/roles/migrationcontroller/templates/controller_config.yml.j2
@@ -51,3 +51,7 @@ data:
   STUNNEL_TCP_PROXY: "{{ stunnel_tcp_proxy }}"
   STUNNEL_VERIFY_CA: "{{ stunnel_verify_ca }}"
   STUNNEL_VERIFY_CA_LEVEL: "{{ stunnel_verify_ca_level }}"
+{% if disable_image_copy is defined %}
+  DISABLE_IMAGE_COPY: "{{ disable_image_copy }}"
+{% endif %}
+


### PR DESCRIPTION
**Please note this is just one of the three PRs that form the fix for the bug 1859998. Other two PRs are [69](https://github.com/konveyor/openshift-velero-plugin/pull/69) and [940](https://github.com/konveyor/mig-controller/pull/940).**

### Description of changes:
The `disable_image_copy` flag is propagated as ENV variable to mig-controller so that it could be used to inhibit migration of the images associated with the imagestream.

Signed-off-by: Padmanabha Venkatagiri Seshadri <seshapad@in.ibm.com>

**Description**


**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
