### PR TITLE
Add documentation for resources migrated by MTC

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,5 +169,5 @@ oc delete oauthclient migration
 
 ## Resources Migrated By Konveyor Operator
 
-Please refer [Resources Migrated By Konveyor Operator](./docs/resources_migrated.md) in order to gain insights regarding what kind of objects/resources
+Please refer to [Resources Migrated By Konveyor Operator](./docs/resources_migrated.md) in order to gain insights regarding what kind of objects/resources
 get migrated by the Konveyor Operator.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Konveyor Operator (mig-operator) installs a system of migration components for m
 		* [Rollback on Migration Failure](#rollback-on-migration-failure)
 * [CORS (Cross-Origin Resource Sharing) Configuration](#cors-cross-origin-resource-sharing-configuration)
 * [Removing Konveyor Operator](#removing-konveyor-operator)
+* [Resources Migrated By Konveyor Operator](#resource-migrated-by-konveyor-operator)
 
 ---
 
@@ -165,3 +166,8 @@ oc delete clusterrolebindings migration-operator velero mig-cluster-admin migrat
 
 oc delete oauthclient migration
 ```
+
+## Resources Migrated By Konveyor Operator
+
+Please refer [Resources Migrated By Konveyor Operator](./docs/resources_migrated.md) in order to gain insights regarding what kind of objects/resources
+get migrated by the Konveyor Operator.

--- a/docs/resources_migrated.md
+++ b/docs/resources_migrated.md
@@ -15,8 +15,8 @@ of Persistent Volume Claims (PVC) and Persistent Volumes (PV) is handled by the 
 - **Custom Resources(CR) and Custom Resource Definitions(CRD):** Any namespace scoped CRs will automatically be included in the migration
 if the namespace is selected by the user for migration. Consequently, the Konveyor operator will grab the CRDs associated with the CRs for migration.
 
-- **Blacklisted Resources:** Some objects/resources are blacklisted by default by the Konveyor operator. These resources are 
-service catalog resources or OLM resources, OLM migration is not handled by Konveyor operator. The blacklisted resources are:
+- **Blocklisted Resources:** Some objects/resources are blocklisted by default and not migrated by the Konveyor operator. These resources are 
+service catalog resources or OLM resources, OLM migration is not handled by Konveyor operator. The blocklisted resources are:
 
 ```
   - imagetags

--- a/docs/resources_migrated.md
+++ b/docs/resources_migrated.md
@@ -16,7 +16,8 @@ of Persistent Volume Claims (PVC) and Persistent Volumes (PV) is handled by the 
 if the namespace is selected by the user for migration. Consequently, the Konveyor operator will also migrate the CRDs associated with the CRs for migration.
 
 - **Excluded Resources:** Some objects/resources are excluded by default from the migration by the Konveyor operator. These resources are 
-service catalog resources or OLM resources, OLM migration is not handled by Konveyor operator. The excluded resources are:
+service catalog resources or OLM resources, OLM migration is not handled by Konveyor operator. The excluded resources are (Please refer the
+[Excluded Resources](usage/ExcludeResources.md) document for more details) :
 
 ```
   - imagetags

--- a/docs/resources_migrated.md
+++ b/docs/resources_migrated.md
@@ -1,0 +1,36 @@
+# Resources Migrated By Konveyor Operator
+
+- **Migration via the configured Migration Plan:** The Konveyor operator allows you to select the namespaces to be migrated 
+during the creation and configuration of a MigPlan, this implies that the **namespace** is the most basic resource that a 
+user can specify for a particular migration and nothing more granular than that.
+
+- **Namespace scoped resources vs Cluster scoped resources:** When a particular namespace is selected for migration, then all the 
+objects/resources (services, pods etc.) pertaining to that namespace are also selected for the migration. But, there might be a case 
+when a namespaced scoped resource depends on a cluster scoped resource, in such a scenario the cluster scoped resource also gets
+migrated by the Konveyor operator. For instance, a Security Context Constraint (SCC) is a cluster scoped resource , and a service account (SA) 
+is a namespace scoped resource, consider that the SA exists in the namespace which is selected for migration by the user then the operator 
+will automatically go and find any SCCs that are applied to this SA and include those in the migration as well. Similarly, the relationship
+of Persistent Volume Claims (PVC) and Persistent Volumes (PV) is handled by the operator. 
+
+- **Custom Resources(CR) and Custom Resource Definitions(CRD):** Any namespace scoped CRs will automatically be included in the migration
+if the namespace is selected by the user for migration. Consequently, the Konveyor operator will grab the CRDs associated with the CRs for migration.
+
+- **Blacklisted Resources:** Some objects/resources are blacklisted by default by the Konveyor operator. These resources are 
+service catalog resources or OLM resources, OLM migration is not handled by Konveyor operator. The blacklisted resources are:
+
+```
+  - imagetags
+  - templateinstances
+  - clusterserviceversions
+  - packagemanifests
+  - subscriptions
+  - servicebrokers
+  - servicebindings
+  - serviceclasses
+  - serviceinstances
+  - serviceplans
+  - operatorgroups
+  - events
+```
+
+**Note:** For more granular information on this topic please refer the [Velero docs.](https://velero.io/docs/v1.4/how-velero-works/)

--- a/docs/resources_migrated.md
+++ b/docs/resources_migrated.md
@@ -13,10 +13,10 @@ will automatically go and find any SCCs that are applied to this SA and include 
 of Persistent Volume Claims (PVC) and Persistent Volumes (PV) is handled by the operator. 
 
 - **Custom Resources(CR) and Custom Resource Definitions(CRD):** Any namespace scoped CRs will automatically be included in the migration
-if the namespace is selected by the user for migration. Consequently, the Konveyor operator will grab the CRDs associated with the CRs for migration.
+if the namespace is selected by the user for migration. Consequently, the Konveyor operator will also migrate the CRDs associated with the CRs for migration.
 
-- **Blocklisted Resources:** Some objects/resources are blocklisted by default and not migrated by the Konveyor operator. These resources are 
-service catalog resources or OLM resources, OLM migration is not handled by Konveyor operator. The blocklisted resources are:
+- **Excluded Resources:** Some objects/resources are excluded by default from the migration by the Konveyor operator. These resources are 
+service catalog resources or OLM resources, OLM migration is not handled by Konveyor operator. The excluded resources are:
 
 ```
   - imagetags

--- a/docs/resources_migrated.md
+++ b/docs/resources_migrated.md
@@ -16,7 +16,7 @@ of Persistent Volume Claims (PVC) and Persistent Volumes (PV) is handled by the 
 if the namespace is selected by the user for migration. Consequently, the Konveyor operator will also migrate the CRDs associated with the CRs for migration.
 
 - **Excluded Resources:** Some objects/resources are excluded by default from the migration by the Konveyor operator. These resources are 
-service catalog resources or OLM resources, OLM migration is not handled by Konveyor operator. The excluded resources are (Please refer the
+service catalog resources or OLM resources, OLM migration is not handled by Konveyor operator. The excluded resources are (Please refer to the
 [Excluded Resources](usage/ExcludeResources.md) document for more details) :
 
 ```


### PR DESCRIPTION
**Description**
This PR does the following:
- Adds a new documentation file pertaining to `Resources migrated by the Konveyor Oeprator`
- fixes https://github.com/konveyor/mig-operator/issues/496

**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
