### PR TITLE
Make controller config always deploy

### DIFF
--- a/roles/migrationcontroller/tasks/main.yml
+++ b/roles/migrationcontroller/tasks/main.yml
@@ -472,6 +472,11 @@
       - migration_deployment_containers is defined
       - item.name == "cam"
 
+    - name: "Set up mig controller configmap"
+      k8s:
+        state: present
+        definition: "{{ lookup('template', 'controller_config.yml.j2') }}"
+
     - name: "Remove mig controller"
       k8s:
         state: absent

--- a/roles/migrationcontroller/templates/controller.yml.j2
+++ b/roles/migrationcontroller/templates/controller.yml.j2
@@ -20,54 +20,6 @@ spec:
     control-plane: controller-manager
     controller-tools.k8s.io: "1.0"
 ---
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  labels:
-    control-plane: controller-manager
-    controller-tools.k8s.io: "1.0"
-  name: migration-controller
-  namespace: {{ mig_namespace }}
-data:
-  PV_LIMIT: "{{ mig_pv_limit }}"
-  POD_LIMIT: "{{ mig_pod_limit }}"
-  NAMESPACE_LIMIT: "{{ mig_namespace_limit }}"
-  CORS_ALLOWED_ORIGINS: {{ cors_origins | join(' ') }}
-  WORKING_DIR: {{ discovery_volume_path }}
-  CLIENT_POD_CPU_LIMIT: "{{ source_rsync_pod_cpu_limits }}"
-  CLIENT_POD_MEMORY_LIMIT: "{{ source_rsync_pod_memory_limits }}"
-  CLIENT_POD_CPU_REQUEST: "{{ source_rsync_pod_cpu_requests }}"
-  CLIENT_POD_MEMORY_REQUEST: "{{ source_rsync_pod_memory_requests }}"
-  TRANSFER_POD_CPU_LIMIT: "{{ target_rsync_pod_cpu_limits }}"
-  TRANSFER_POD_MEMORY_LIMIT: "{{ target_rsync_pod_memory_limits }}"
-  TRANSFER_POD_CPU_REQUEST: "{{ target_rsync_pod_cpu_requests }}"
-  TRANSFER_POD_MEMORY_REQUEST: "{{ target_rsync_pod_memory_requests }}"
-  STUNNEL_POD_CPU_LIMIT: "{{ stunnel_pod_cpu_limits }}"
-  STUNNEL_POD_MEMORY_LIMIT: "{{ stunnel_pod_memory_limits }}"
-  STUNNEL_POD_CPU_REQUEST: "{{ stunnel_pod_cpu_requests }}"
-  STUNNEL_POD_MEMORY_REQUEST: "{{ stunnel_pod_memory_requests }}"
-{% if rsync_opt_bwlimit is defined and rsync_opt_bwlimit|int > 0 %}
-  RSYNC_OPT_BWLIMIT: "{{ rsync_opt_bwlimit }}"
-{% endif %}
-{% if rsync_opt_partial is defined %}
-  RSYNC_OPT_PARTIAL: "{{ rsync_opt_partial }}"
-{% endif %}
-{% if rsync_opt_archive is defined %}
-  RSYNC_OPT_ARCHIVE: "{{ rsync_opt_archive }}"
-{% endif %}
-{% if rsync_opt_delete is defined %}
-  RSYNC_OPT_DELETE: "{{ rsync_opt_delete }}"
-{% endif %}
-{% if rsync_opt_hardlinks is defined %}
-  RSYNC_OPT_HARDLINKS: "{{ rsync_opt_hardlinks }}"
-{% endif %}
-{% if rsync_opt_info is defined %}
-  RSYNC_OPT_INFO: "{{ rsync_opt_info }}"
-{% endif %}
-{% if rsync_opt_extras is defined %}
-  RSYNC_OPT_EXTRAS: "{{ rsync_opt_extras }}"
-{% endif %}
----
 {% if lookup('k8s', cluster_info='version').kubernetes.minor|replace('+', '')|int < 9 %}
 apiVersion: apps/v1beta1
 {% else %}

--- a/roles/migrationcontroller/templates/controller_config.yml.j2
+++ b/roles/migrationcontroller/templates/controller_config.yml.j2
@@ -1,0 +1,49 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"
+  name: migration-controller
+  namespace: {{ mig_namespace }}
+data:
+  PV_LIMIT: "{{ mig_pv_limit }}"
+  POD_LIMIT: "{{ mig_pod_limit }}"
+  NAMESPACE_LIMIT: "{{ mig_namespace_limit }}"
+  CORS_ALLOWED_ORIGINS: {{ cors_origins | join(' ') }}
+  WORKING_DIR: {{ discovery_volume_path }}
+  CLIENT_POD_CPU_LIMIT: "{{ source_rsync_pod_cpu_limits }}"
+  CLIENT_POD_MEMORY_LIMIT: "{{ source_rsync_pod_memory_limits }}"
+  CLIENT_POD_CPU_REQUEST: "{{ source_rsync_pod_cpu_requests }}"
+  CLIENT_POD_MEMORY_REQUEST: "{{ source_rsync_pod_memory_requests }}"
+  TRANSFER_POD_CPU_LIMIT: "{{ target_rsync_pod_cpu_limits }}"
+  TRANSFER_POD_MEMORY_LIMIT: "{{ target_rsync_pod_memory_limits }}"
+  TRANSFER_POD_CPU_REQUEST: "{{ target_rsync_pod_cpu_requests }}"
+  TRANSFER_POD_MEMORY_REQUEST: "{{ target_rsync_pod_memory_requests }}"
+  STUNNEL_POD_CPU_LIMIT: "{{ stunnel_pod_cpu_limits }}"
+  STUNNEL_POD_MEMORY_LIMIT: "{{ stunnel_pod_memory_limits }}"
+  STUNNEL_POD_CPU_REQUEST: "{{ stunnel_pod_cpu_requests }}"
+  STUNNEL_POD_MEMORY_REQUEST: "{{ stunnel_pod_memory_requests }}"
+{% if rsync_opt_bwlimit is defined and rsync_opt_bwlimit|int > 0 %}
+  RSYNC_OPT_BWLIMIT: "{{ rsync_opt_bwlimit }}"
+{% endif %}
+{% if rsync_opt_partial is defined %}
+  RSYNC_OPT_PARTIAL: "{{ rsync_opt_partial }}"
+{% endif %}
+{% if rsync_opt_archive is defined %}
+  RSYNC_OPT_ARCHIVE: "{{ rsync_opt_archive }}"
+{% endif %}
+{% if rsync_opt_delete is defined %}
+  RSYNC_OPT_DELETE: "{{ rsync_opt_delete }}"
+{% endif %}
+{% if rsync_opt_hardlinks is defined %}
+  RSYNC_OPT_HARDLINKS: "{{ rsync_opt_hardlinks }}"
+{% endif %}
+{% if rsync_opt_info is defined %}
+  RSYNC_OPT_INFO: "{{ rsync_opt_info }}"
+{% endif %}
+{% if rsync_opt_extras is defined %}
+  RSYNC_OPT_EXTRAS: "{{ rsync_opt_extras }}"
+{% endif %}
+


### PR DESCRIPTION
**Description**

This PR ensures that the mig-controller configmap will still be deployed even if an admin has turned off the in-cluster controller. This enables the local controller dev workflow.

Fix for https://github.com/konveyor/mig-controller/issues/918

For context, some recent changes added direct migration config in this configmap, which broke the local dev workflow.