### PR TITLE
add migration_rsyncd_route_labels to the CR

### DIFF
--- a/roles/migrationcontroller/defaults/main.yml
+++ b/roles/migrationcontroller/defaults/main.yml
@@ -84,6 +84,7 @@ migration_stage_repo: "{{ lookup( 'env', 'VELERO_RESTIC_RESTORE_HELPER_REPO') }}
 migration_stage_version: "{{ snapshot_tag | default(lookup( 'env', 'VELERO_RESTIC_RESTORE_HELPER_TAG')) }}"
 migration_stage_image_fqin: "{{ migration_stage_image }}:{{ migration_stage_version }}"
 migration_rsync_privileged: false
+migration_rsyncd_route_labels: {}
 olm_managed: false
 registry: "{{ lookup( 'env', 'REGISTRY') }}"
 project: "{{ lookup( 'env', 'PROJECT') }}"

--- a/roles/migrationcontroller/templates/controller.yml.j2
+++ b/roles/migrationcontroller/templates/controller.yml.j2
@@ -52,6 +52,7 @@ spec:
         | join(mig_pod_limit | string)
         | join(mig_namespace_limit | string)
         | join(discovery_volume_path | string)
+        | join(migration_rsyncd_route_labels | to_json)
         | hash('sha1') }}"
     spec:
       serviceAccountName: migration-controller

--- a/roles/migrationcontroller/templates/controller_config.yml.j2
+++ b/roles/migrationcontroller/templates/controller_config.yml.j2
@@ -25,6 +25,7 @@ data:
   STUNNEL_POD_MEMORY_LIMIT: "{{ stunnel_pod_memory_limits }}"
   STUNNEL_POD_CPU_REQUEST: "{{ stunnel_pod_cpu_requests }}"
   STUNNEL_POD_MEMORY_REQUEST: "{{ stunnel_pod_memory_requests }}"
+  RSYNCD_ROUTE_LABELS: "{{ migration_rsyncd_route_labels | to_json }}"
 {% if rsync_opt_bwlimit is defined and rsync_opt_bwlimit|int > 0 %}
   RSYNC_OPT_BWLIMIT: "{{ rsync_opt_bwlimit }}"
 {% endif %}


### PR DESCRIPTION
**Description**
This adds an option to add labels on rsyncd routes.

**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
