### PR TITLE
Bug 1917810: Add imagestreamtags to skipped resources when image migration is disabled

### DIFF
--- a/roles/migrationcontroller/tasks/main.yml
+++ b/roles/migrationcontroller/tasks/main.yml
@@ -48,6 +48,10 @@
     when: disable_image_migration|bool and 'imagestreams' not in excluded_resources
 
   - set_fact:
+      all_excluded_resources: "{{ all_excluded_resources + ['imagestreamtags'] }}"
+    when: disable_image_migration|bool and 'imagestreamtags' not in excluded_resources
+
+  - set_fact:
       all_excluded_resources: "{{ all_excluded_resources + ['persistentvolumes'] }}"
     when: disable_pv_migration|bool and 'persistentvolumes' not in excluded_resources
 


### PR DESCRIPTION
When disable_image_migration is set to True, this PR will make sure imagestreamtags are added to skipped resources list. 

**Description**


**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
