### PR TITLE
add exitCode and containerElapsedTime to dvmp CR for rsync client pods

### DIFF
--- a/deploy/olm-catalog/bundle/manifests/migration.openshift.io_directvolumemigrationprogresses.yaml
+++ b/deploy/olm-catalog/bundle/manifests/migration.openshift.io_directvolumemigrationprogresses.yaml
@@ -166,6 +166,11 @@ spec:
                 - type
                 type: object
               type: array
+            containerElapsedTime:
+              type: string
+            exitCode:
+              format: int32
+              type: integer
             lastObservedProgressPercent:
               type: string
             lastObservedTransferRate:

--- a/roles/migrationcontroller/files/migration.openshift.io_directvolumemigrationprogresses.yaml
+++ b/roles/migrationcontroller/files/migration.openshift.io_directvolumemigrationprogresses.yaml
@@ -167,6 +167,11 @@ spec:
                 - type
                 type: object
               type: array
+            containerElapsedTime:
+              type: string
+            exitCode:
+              format: int32
+              type: integer
             lastObservedProgressPercent:
               type: string
             lastObservedTransferRate:


### PR DESCRIPTION
**Description**
This PR changes the DVMP CRs to add two new fields to the status

**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [x] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
