### PR TITLE
Fixes #557 - Improves Daemonset Node Selector

### DIFF
--- a/docs/usage/1.md
+++ b/docs/usage/1.md
@@ -218,7 +218,20 @@ restic-mh5lb                          1/1       Running   0          7m
 restic-p849t                          1/1       Running   0          7m
 velero-84b8d9878b-gklfb               1/1       Running   0          8m
 ```
+# 1.3.4 Limit daemonset to desired nodes
+If you need to limit the nodes the restic daemonset runs on:
 
+* Add the daemonset_node_selector to the MigrationController CR, for example:
+```
+spec:
+  daemonset_node_selector:
+    node-role.kubernetes.io/worker: ""
+    topology.kubernetes.io/zone: us-east-1b
+```
+* Values for selectors can be updated normally, i.e. `us-east-1b` can be updated to `us-east-1a` in the above example.
+* If a selector needs to be removed completely do one of the following:
+    * Update the MigrationController CR with the new desired values then manually remove the unwanted selectors from the daemonset.
+    * Set  `daemonset_node_selector: null` to clear all selectors. Once the daemonset updates add a new set of selectors, if desired.
 
 ## 1.4 CORS Configuration (CAM 1.0 Only)
 

--- a/roles/migrationcontroller/templates/velero.yml.j2
+++ b/roles/migrationcontroller/templates/velero.yml.j2
@@ -187,7 +187,7 @@ spec:
         name: restic
     spec:
 {% if _migration_openshift_io_migrationcontroller_spec.daemonset_node_selector is defined %}
-      nodeSelector: {{ _migration_openshift_io_migrationcontroller_spec.daemonset_node_selector }}
+      nodeSelector: {{ _migration_openshift_io_migrationcontroller_spec.daemonset_node_selector | to_yaml }}
 {% else %}
       nodeSelector: null
 {% endif %}

--- a/roles/migrationcontroller/templates/velero.yml.j2
+++ b/roles/migrationcontroller/templates/velero.yml.j2
@@ -186,8 +186,10 @@ spec:
       labels:
         name: restic
     spec:
-{% if daemonset_node_selector is defined %}
-      nodeSelector: {{ daemonset_node_selector }}
+{% if _migration_openshift_io_migrationcontroller_spec.daemonset_node_selector is defined %}
+      nodeSelector: {{ _migration_openshift_io_migrationcontroller_spec.daemonset_node_selector }}
+{% else %}
+      nodeSelector: null
 {% endif %}
       serviceAccountName: velero
       securityContext:


### PR DESCRIPTION
**Description**

Closes https://github.com/konveyor/mig-operator/issues/557

This PR makes improvements to specifying the nodeSelector based on oddities QE noticed on BZ 1853534:
Some observations so far:

When you specify the nodeSelector in the MigrationController CR Ansible is replacing dashes in the key with underscores. node-role becomes node_role, which is not a valid DNS-1123 name.

When you specify a value of `true` or `false` we get hung up because the value needs to be sent as a string and not a bool.

node-role.kubernetes.io/master=true or node-role.kubernetes.io/worker=true do not work for me at all. It looks like it should be as you found node-role.kubernetes.io/worker='', which will schedule.

By supplying it as a string you were overcoming all of these issues.

After dealing with the above I did not encounter a problem with:
topology.kubernetes.io/zone: us-east-1b

I can successfully define the daemonset_node_selector like so:
```
spec:
  daemonset_node_selector:
    node-role.kubernetes.io/worker: ""
    topology.kubernetes.io/zone: us-east-1b
```

Instructions on how to use this parameter have been added, especially since removing selectors is counterintuitive.

**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
