### PR TITLE
Update Migration via API docs with secret creation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Setting for the max allowable number of resources in a Migration Plan. The defau
 
 - [Direct Migration using API](./docs/usage/DirectMigrationExampleAPI.md)
 - [Indirect Migration using API](./docs/usage/IndirectMigrationExampleAPI.md)
+- [MTC API refernce](./docs/usage/MTCAPIDoc.md)
 
 ## CORS (Cross-Origin Resource Sharing) Configuration
 

--- a/docs/usage/DirectMigrationExampleAPI.md
+++ b/docs/usage/DirectMigrationExampleAPI.md
@@ -32,6 +32,29 @@ Command to create destination MigCluster instance:
 oc create -f destination-migcluster.yaml
 ```
 
+Before adding the remote source cluster, we need to create a Service Account Secret on the host cluster. This is needed so
+that the Migration Controller can perform migration operations and actions on the remote source cluster.
+
+Store the Service Account Secret yaml manifest in `sa-secret-remote.yaml`
+```
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sa-token-remote
+  namespace: openshift-config
+type: Opaque
+data:
+  # [!] Change saToken to contain a base64 encoded SA token with cluster-admin 
+  #     privileges on the remote cluster.
+  #     `oc sa get-token migration-controller -n openshift-migration | base64 -w 0`
+  saToken: <your-base64-encoded-aws-sa-token-here>
+``` 
+
+Command to create Service Account Secret instance:
+``` 
+oc create -f sa-secret-remote.yaml
+```
+
 Now let's add the second cluster, that is the source cluster.
 
 Store the source MigCluster yaml manifest in `source-migcluster.yaml`:
@@ -46,7 +69,7 @@ spec:
   insecure: true
   isHostCluster: false
   serviceAccountSecretRef:
-    name: src-ocp-3-cluster-k2vnk
+    name: sa-token-remote
     namespace: openshift-config
   url: 'https://master.ocp3.mycluster.com/'
 ```
@@ -56,7 +79,8 @@ oc create -f source-migcluster.yaml
 ```
 
 **Note:** Please ensure that the `exposedRegistryPath` is appropriately specified, it is a must for
-facilitating **Direct Image Migration.**
+facilitating **Direct Image Migration.** Also, make sure the `serviceAccountSecretRef` details refer to
+the same Service Account Secret we created before addition of the source cluster.
 
 Before moving ahead, please verify that both the MigCluster instances are in a `Ready` state and there are no 
 critical conditions associated with these instances, if there are any issues or critical conditions present, please 
@@ -67,6 +91,38 @@ This step involves the configuration of the object storage to be utilized during
 migration.
 
 For our example we will be configuring AWS S3 object storage as our MigStorage.
+
+Before creating the MigStorage instance, we need a Secret to hold the storage authentication details.
+
+Store the storage Secret yaml manifest in `mig-storage-creds.yaml`
+
+```
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: openshift-config
+  name: migstorage-creds
+type: Opaque
+data:
+  # [!] If using S3 / AWS, change aws-access-key-id and aws-secret-access-key to contain the base64
+  #      encoded keys needed to authenticate with the storage specified in migstorage.
+  
+  # [!] CAUTION: It's easy to miss the step of base64 encoding your AWS credentials when inputting
+  #     them to this secret. since AWS credentials are base64 compatible already. Be _sure_ to run
+  #     `echo -n "<key>" | base64 -w 0` on your access and secret key before providing them below.
+  
+  # [Note] these credentials will be injected into cloud-credentials in the 'velero' namespace.
+  aws-access-key-id: aGVsbG8K
+  aws-secret-access-key: aGVsbG8K
+```
+
+Command to create MigStorage Secret instance:
+``` 
+oc create -f mig-storage-creds.yaml
+```
+
+Now, lets create the MigStorage instance.
 
 Store the MigStorage yaml manifest in `migstorage.yaml`
 
@@ -80,12 +136,12 @@ spec:
   backupStorageConfig:
     awsBucketName: mybucket-6109f5e9711c8c58131acdd2f490f451
     credsSecretRef:
-      name: aws-s3-jg74j
+      name: migstorage-creds
       namespace: openshift-config
   backupStorageProvider: aws
   volumeSnapshotConfig:
     credsSecretRef:
-      name: aws-s3-jg74j
+      name: migstorage-creds
       namespace: openshift-config
   volumeSnapshotProvider: aws
 ```
@@ -96,7 +152,8 @@ oc create -f migstorage.yaml
 ```
 
 **Note:** Please ensure that the secrets referenced in the `credsSecretRef` of 
-`backupStorageConfig` as well as the `volumeSnapshotConfig:` exist in the specifications provided.
+`backupStorageConfig` as well as the `volumeSnapshotConfig:` exist in the specifications provided (in our example it's the
+same secret we created before creation of MigStorage instance).
 
 Once again, before moving further please ensure that the MigStorage instance is in `Ready` state 
 and there are not critical conditions associated with the same, if there are any issues or critical conditions present,
@@ -116,7 +173,7 @@ Store the MigPlan yaml manifest in `migplan.yaml`
 apiVersion: migration.openshift.io/v1alpha1
 kind: MigPlan
 metadata:
-  name: mtc-api-example
+  name: mtc-api-example-migplan
   namespace: openshift-migration
 spec:
   destMigClusterRef:
@@ -180,11 +237,11 @@ Store the MigMigration yaml manifest in `migmigration.yaml`:
 apiVersion: migration.openshift.io/v1alpha1
 kind: MigMigration
 metadata:
-  name: 0f487a20-5ae9-11eb-aa56-713724da7e23
+  name: mtc-api-example-migration
   namespace: openshift-migration
 spec:
   migPlanRef:
-    name: mtc-api-example
+    name: mtc-api-example-migplan
     namespace: openshift-migration
   quiescePods: true
   stage: false

--- a/docs/usage/IndirectMigrationExampleAPI.md
+++ b/docs/usage/IndirectMigrationExampleAPI.md
@@ -12,7 +12,7 @@ The steps to perform a InDirect Migration using Migration Toolkit for Containers
 This step involves addition and configuration of the source as well as the destination clusters 
 involved in the migration.
 
-- At first, let's create a MigCluster instance in order to add the destination cluster. 
+At first, let's create a MigCluster instance in order to add the destination cluster. 
 In our case this cluster is also the host cluster where Migration controller resides and is
 already configured, you do not need to add this cluster. 
 
@@ -32,7 +32,30 @@ Command to create destination MigCluster instance:
 oc create -f destination-migcluster.yaml
 ```
 
-- Now let's add the second cluster, that is the source cluster.
+Before adding the remote source cluster, we need to create a Service Account Secret on the host cluster. This is needed so
+that the Migration Controller can perform migration operations and actions on the remote source cluster.
+
+Store the Service Account Secret yaml manifest in `sa-secret-remote.yaml`
+```
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sa-token-remote
+  namespace: openshift-config
+type: Opaque
+data:
+  # [!] Change saToken to contain a base64 encoded SA token with cluster-admin 
+  #     privileges on the remote cluster.
+  #     `oc sa get-token migration-controller -n openshift-migration | base64 -w 0`
+  saToken: <your-base64-encoded-aws-sa-token-here>
+``` 
+
+Command to create Service Account Secret instance:
+``` 
+oc create -f sa-secret-remote.yaml
+```
+
+Now let's add the second cluster, that is the source cluster.
 
 Store the source MigCluster yaml manifest in `source-migcluster.yaml`:
 ``` 
@@ -45,7 +68,7 @@ spec:
   insecure: true
   isHostCluster: false
   serviceAccountSecretRef:
-    name: src-ocp-3-cluster-k2vnk
+    name: sa-token-remote
     namespace: openshift-config
   url: 'https://master.ocp3.mycluster.com/'
 ```
@@ -53,6 +76,9 @@ Command to create source MigCluster instance:
 ``` 
 oc create -f source-migcluster.yaml
 ```
+
+**Note:** Please make sure the `serviceAccountSecretRef` details refer to the same Service Account Secret we created
+before addition of the source cluster.
 
 Before moving ahead, please verify that both the MigCluster instances are in a `Ready` state and there are no 
 critical conditions associated with these instances, if there are any issues or critical conditions present, please 
@@ -64,6 +90,38 @@ migration.
 
 For our example we will be configuring AWS S3 object storage as our MigStorage.
 This step is to be carried out on host cluster (where the Migration Controller resides).
+
+Before creating the MigStorage instance, we need a Secret to hold the storage authentication details.
+
+Store the storage Secret yaml manifest in `mig-storage-creds.yaml`
+
+```
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: openshift-config
+  name: migstorage-creds
+type: Opaque
+data:
+  # [!] If using S3 / AWS, change aws-access-key-id and aws-secret-access-key to contain the base64
+  #      encoded keys needed to authenticate with the storage specified in migstorage.
+  
+  # [!] CAUTION: It's easy to miss the step of base64 encoding your AWS credentials when inputting
+  #     them to this secret. since AWS credentials are base64 compatible already. Be _sure_ to run
+  #     `echo -n "<key>" | base64 -w 0` on your access and secret key before providing them below.
+  
+  # [Note] these credentials will be injected into cloud-credentials in the 'velero' namespace.
+  aws-access-key-id: aGVsbG8K
+  aws-secret-access-key: aGVsbG8K
+```
+
+Command to create MigStorage Secret instance:
+``` 
+oc create -f mig-storage-creds.yaml
+```
+
+Now, lets create the MigStorage instance.
 
 Store the MigStorage yaml manifest in `migstorage.yaml`
 
@@ -77,12 +135,12 @@ spec:
   backupStorageConfig:
     awsBucketName: mybucket-6109f5e9711c8c58131acdd2f490f451
     credsSecretRef:
-      name: aws-s3-jg74j
+      name: migstorage-creds
       namespace: openshift-config
   backupStorageProvider: aws
   volumeSnapshotConfig:
     credsSecretRef:
-      name: aws-s3-jg74j
+      name: migstorage-creds
       namespace: openshift-config
   volumeSnapshotProvider: aws
 ```
@@ -93,7 +151,8 @@ oc create -f migstorage.yaml
 ```
 
 **Note:** Please ensure that the secrets referenced in the `credsSecretRef` of 
-`backupStorageConfig` as well as the `volumeSnapshotConfig:` exist in the specifications provided.
+`backupStorageConfig` as well as the `volumeSnapshotConfig:` exist in the specifications provided (in our example it's the
+same secret we created before creation of MigStorage instance).
 
 Once again, before moving further please ensure that the MigStorage instance is in `Ready` state 
 and there are not critical conditions associated with the same, if there are any issues or critical conditions present,
@@ -113,7 +172,7 @@ Store the MigPlan yaml manifest in `migplan.yaml`
 apiVersion: migration.openshift.io/v1alpha1
 kind: MigPlan
 metadata:
-  name: mtc-api-example
+  name: mtc-api-example-migplan
   namespace: openshift-migration
 spec:
   destMigClusterRef:
@@ -175,11 +234,11 @@ Store the MigMigration yaml manifest in `migmigration.yaml`:
 apiVersion: migration.openshift.io/v1alpha1
 kind: MigMigration
 metadata:
-  name: 982ba500-5b3a-11eb-bd49-4734b4f50789
+  name: mtc-api-example-migration
   namespace: openshift-migration
 spec:
   migPlanRef:
-    name: mtc-api-example
+    name: mtc-api-example-migplan
     namespace: openshift-migration
   quiescePods: true
   stage: false


### PR DESCRIPTION
**Description**
This PR does the following:
- Adds a step on how to create a SA secret for remote cluster involved in the migration.
- Also, details regarding creation of secret on host cluster to hold the object storage authentication credentials.
- MTC API reference link

**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
