### PR TITLE
Improve proxy config

### DIFF
--- a/roles/migrationcontroller/tasks/main.yml
+++ b/roles/migrationcontroller/tasks/main.yml
@@ -221,6 +221,7 @@
     k8s:
       state: "{{ velero_state }}"
       definition: "{{ lookup('template', 'velero.yml.j2') }}"
+      merge_type: merge
 
   - name: "Set up migration CRDs"
     k8s:
@@ -526,6 +527,7 @@
       k8s:
         state: "{{ controller_state }}"
         definition: "{{ lookup('template', 'controller.yml.j2') }}"
+        merge_type: merge
     rescue:
     - name: "Remove mig controller"
       k8s:
@@ -536,6 +538,7 @@
       k8s:
         state: "{{ controller_state }}"
         definition: "{{ lookup('template', 'controller.yml.j2') }}"
+        merge_type: merge
 
   - name: "Set up mig log reader"
     k8s:


### PR DESCRIPTION
**Description**
Fixes https://github.com/konveyor/mig-operator/issues/580

While testing https://github.com/konveyor/mig-operator/pull/579 I managed to cause all the other containers to crash after adding a nonsense proxy value `foo.foo`. There was no way to remove them other than deleting the deployments and letting them be recreated.

**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
