### PR TITLE
add variable to enable/disable intelligent pv resizing

### DIFF
--- a/roles/migrationcontroller/defaults/main.yml
+++ b/roles/migrationcontroller/defaults/main.yml
@@ -86,6 +86,7 @@ migration_stage_version: "{{ snapshot_tag | default(lookup( 'env', 'VELERO_RESTI
 migration_stage_image_fqin: "{{ migration_stage_image }}:{{ migration_stage_version }}"
 migration_rsync_privileged: false
 olm_managed: false
+enable_intelligent_pv_resize: false
 registry: "{{ lookup( 'env', 'REGISTRY') }}"
 project: "{{ lookup( 'env', 'PROJECT') }}"
 restic_pv_host_path: /var/lib/kubelet/pods

--- a/roles/migrationcontroller/defaults/main.yml
+++ b/roles/migrationcontroller/defaults/main.yml
@@ -86,7 +86,7 @@ migration_stage_version: "{{ snapshot_tag | default(lookup( 'env', 'VELERO_RESTI
 migration_stage_image_fqin: "{{ migration_stage_image }}:{{ migration_stage_version }}"
 migration_rsync_privileged: false
 olm_managed: false
-enable_intelligent_pv_resize: false
+enable_intelligent_pv_resize: true
 registry: "{{ lookup( 'env', 'REGISTRY') }}"
 project: "{{ lookup( 'env', 'PROJECT') }}"
 restic_pv_host_path: /var/lib/kubelet/pods

--- a/roles/migrationcontroller/templates/controller.yml.j2
+++ b/roles/migrationcontroller/templates/controller.yml.j2
@@ -61,6 +61,8 @@ spec:
           value: webhook-server-secret
         - name: MIGRATION_REGISTRY_IMAGE
           value: {{ migration_registry_image_fqin }}
+        - name: ENABLE_INTELLIGENT_PV_RESIZE
+          value: {{ enable_intelligent_pv_resize }}
 {% if http_proxy|length >0 %}
         - name: HTTP_PROXY
           value: {{ http_proxy }}

--- a/roles/migrationcontroller/templates/controller.yml.j2
+++ b/roles/migrationcontroller/templates/controller.yml.j2
@@ -61,8 +61,6 @@ spec:
           value: webhook-server-secret
         - name: MIGRATION_REGISTRY_IMAGE
           value: {{ migration_registry_image_fqin }}
-        - name: ENABLE_INTELLIGENT_PV_RESIZE
-          value: {{ enable_intelligent_pv_resize }}
 {% if http_proxy|length >0 %}
         - name: HTTP_PROXY
           value: {{ http_proxy }}

--- a/roles/migrationcontroller/templates/controller_config.yml.j2
+++ b/roles/migrationcontroller/templates/controller_config.yml.j2
@@ -25,7 +25,7 @@ data:
   STUNNEL_POD_MEMORY_LIMIT: "{{ stunnel_pod_memory_limits }}"
   STUNNEL_POD_CPU_REQUEST: "{{ stunnel_pod_cpu_requests }}"
   STUNNEL_POD_MEMORY_REQUEST: "{{ stunnel_pod_memory_requests }}"
-  ENABLE_INTELLIGENT_PV_RESIZE: {{ enable_intelligent_pv_resize }}
+  ENABLE_INTELLIGENT_PV_RESIZE: "{{ enable_intelligent_pv_resize }}"
 {% if rsync_opt_bwlimit is defined and rsync_opt_bwlimit|int > 0 %}
   RSYNC_OPT_BWLIMIT: "{{ rsync_opt_bwlimit }}"
 {% endif %}

--- a/roles/migrationcontroller/templates/controller_config.yml.j2
+++ b/roles/migrationcontroller/templates/controller_config.yml.j2
@@ -25,6 +25,7 @@ data:
   STUNNEL_POD_MEMORY_LIMIT: "{{ stunnel_pod_memory_limits }}"
   STUNNEL_POD_CPU_REQUEST: "{{ stunnel_pod_cpu_requests }}"
   STUNNEL_POD_MEMORY_REQUEST: "{{ stunnel_pod_memory_requests }}"
+  ENABLE_INTELLIGENT_PV_RESIZE: {{ enable_intelligent_pv_resize }}
 {% if rsync_opt_bwlimit is defined and rsync_opt_bwlimit|int > 0 %}
   RSYNC_OPT_BWLIMIT: "{{ rsync_opt_bwlimit }}"
 {% endif %}


### PR DESCRIPTION
**Description**
This PR adds a new variable to enable disable intelligent pv resizing

**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
