### PR TITLE
Add global flag for automatic PV resizing

### DIFF
--- a/roles/migrationcontroller/defaults/main.yml
+++ b/roles/migrationcontroller/defaults/main.yml
@@ -41,6 +41,7 @@ target_rsync_pod_cpu_limits: '1'
 target_rsync_pod_cpu_requests: '400m'
 target_rsync_pod_memory_limits: '1Gi'
 target_rsync_pod_memory_requests: '1Gi'
+dvm_automatic_pvresizing: false
 hook_runner_image: "{{ registry }}/{{ project }}/{{ hook_runner_repo }}"
 hook_runner_repo: "{{ lookup( 'env', 'HOOK_RUNNER_REPO') }}"
 hook_runner_version: "{{ snapshot_tag | default(lookup( 'env', 'HOOK_RUNNER_TAG')) }}"

--- a/roles/migrationcontroller/defaults/main.yml
+++ b/roles/migrationcontroller/defaults/main.yml
@@ -41,7 +41,7 @@ target_rsync_pod_cpu_limits: '1'
 target_rsync_pod_cpu_requests: '400m'
 target_rsync_pod_memory_limits: '1Gi'
 target_rsync_pod_memory_requests: '1Gi'
-dvm_automatic_pvresizing: false
+enable_dvm_pv_resizing: false
 hook_runner_image: "{{ registry }}/{{ project }}/{{ hook_runner_repo }}"
 hook_runner_repo: "{{ lookup( 'env', 'HOOK_RUNNER_REPO') }}"
 hook_runner_version: "{{ snapshot_tag | default(lookup( 'env', 'HOOK_RUNNER_TAG')) }}"

--- a/roles/migrationcontroller/templates/controller_config.yml.j2
+++ b/roles/migrationcontroller/templates/controller_config.yml.j2
@@ -26,7 +26,7 @@ data:
   STUNNEL_POD_CPU_REQUEST: "{{ stunnel_pod_cpu_requests }}"
   STUNNEL_POD_MEMORY_REQUEST: "{{ stunnel_pod_memory_requests }}"
   ENABLE_INTELLIGENT_PV_RESIZE: "{{ enable_intelligent_pv_resize }}"
-  DVM_AUTOMATIC_PVRESIZING: "{{ dvm_automatic_pvresizing }}"
+  ENABLE_DVM_PV_RESIZING: "{{ enable_dvm_pv_resizing }}"
 {% if rsync_opt_bwlimit is defined and rsync_opt_bwlimit|int > 0 %}
   RSYNC_OPT_BWLIMIT: "{{ rsync_opt_bwlimit }}"
 {% endif %}

--- a/roles/migrationcontroller/templates/controller_config.yml.j2
+++ b/roles/migrationcontroller/templates/controller_config.yml.j2
@@ -26,6 +26,7 @@ data:
   STUNNEL_POD_CPU_REQUEST: "{{ stunnel_pod_cpu_requests }}"
   STUNNEL_POD_MEMORY_REQUEST: "{{ stunnel_pod_memory_requests }}"
   ENABLE_INTELLIGENT_PV_RESIZE: "{{ enable_intelligent_pv_resize }}"
+  DVM_AUTOMATIC_PVRESIZING: "{{ dvm_automatic_pvresizing }}"
 {% if rsync_opt_bwlimit is defined and rsync_opt_bwlimit|int > 0 %}
   RSYNC_OPT_BWLIMIT: "{{ rsync_opt_bwlimit }}"
 {% endif %}


### PR DESCRIPTION
**Description**
This PR does the following:
- Adds a global flag called `enable_dvm_pv_resizing` which indicates whether to automatically resize PVs or not
- Default value of this flag is `false`
- Flag is used in https://github.com/konveyor/mig-controller/pull/965

**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
