### PR TITLE
add custom scc for rsync that is exact copy of anyuid (#575)

### DIFF
--- a/deploy/olm-catalog/bundle/manifests/konveyor-operator.v1.4.2.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/bundle/manifests/konveyor-operator.v1.4.2.clusterserviceversion.yaml
@@ -651,7 +651,7 @@ spec:
           - use
           resourceNames:
           - privileged
-          - anyuid
+          - rsync-anyuid
         - apiGroups:
           - apps.openshift.io
           - route.openshift.io

--- a/roles/migrationcontroller/tasks/main.yml
+++ b/roles/migrationcontroller/tasks/main.yml
@@ -107,6 +107,10 @@
       restic_pv_host_path: /var/lib/origin/openshift.local.volumes/pods
     when: infrastructures is not defined or infrastructures.resources|length == 0
 
+  # look up api_groups for routes and scc
+  - set_fact:
+      api_groups: "{{ lookup('k8s', cluster_info='api_groups') }}"
+
   # This is only here to ease testing with openshift 3 dev environments
   - set_fact:
       restic_pv_host_path: /tmp/openshift.local.clusterup/openshift.local.volumes/pods
@@ -245,6 +249,14 @@
       definition: "{{ lookup('template', 'mig_rbac.yml.j2') }}"
     when: not olm_managed
 
+  # Create custom SCC for all clusters. For <3.11 scc.users fields will drive the
+  # behavior, for others, RBAC will.
+  - name: "Set up rsync-anyuid SCC"
+    k8s:
+      state: present
+      definition: "{{ lookup('template', 'custom-rsync-anyuid.yml.j2') }}"
+    when: "'security.openshift.io' in api_groups"
+
   - when: migration_controller or migration_ui
     block:
     - name: Set default CORS URLs
@@ -262,9 +274,6 @@
     - monitoring-service.yml.j2
     - monitoring-role.yml.j2
     - monitoring-rolebinding.yml.j2
-
-  - set_fact:
-      api_groups: "{{ lookup('k8s', cluster_info='api_groups') }}"
 
   - name: Check if mig ui route exists already so we don't update it
     k8s_facts:

--- a/roles/migrationcontroller/templates/custom-rsync-anyuid.yml.j2
+++ b/roles/migrationcontroller/templates/custom-rsync-anyuid.yml.j2
@@ -1,0 +1,41 @@
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities: null
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups: []
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: rsync-anyuid provides all features of the restricted SCC
+      but allows users to run with any UID and any GID. This is specifically for the MTC
+      controller to run rsync for copping data from one pvc to another.
+    release.openshift.io/create-only: "true"
+  name: rsync-anyuid
+{# unsetting the priority will make it priority 0, i.e. lower priority than anyuid #}
+{# priority: 10 #}
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- MKNOD
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users:
+- system:serviceaccount:{{ mig_namespace }}:migration-controller
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- projected
+- secret

--- a/roles/migrationcontroller/templates/mig_rbac.yml.j2
+++ b/roles/migrationcontroller/templates/mig_rbac.yml.j2
@@ -71,7 +71,7 @@ rules:
 {% if migration_rsync_privileged %}
   - privileged
 {% else %}
-  - anyuid
+  - rsync-anyuid
 {% endif %}
 - apiGroups:
   - ""


### PR DESCRIPTION
- add custom scc for rsync that is exact copy of anyuid
- remove user groups and lower the priority
- refactor for handling openshift specific apis

**Description**
Cherry-pick of #575 

**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [x] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
