### PR TITLE
Cherry-pick operator version check

### DIFF
--- a/deploy/olm-catalog/bundle/manifests/migration.openshift.io_migclusters.yaml
+++ b/deploy/olm-catalog/bundle/manifests/migration.openshift.io_migclusters.yaml
@@ -25,6 +25,7 @@ spec:
     listKind: MigClusterList
     plural: migclusters
     singular: migcluster
+  preserveUnknownFields: false
   scope: Namespaced
   subresources: {}
   validation:
@@ -47,19 +48,33 @@ spec:
           description: MigClusterSpec defines the desired state of MigCluster
           properties:
             azureResourceGroup:
+              description: For azure clusters -- it's the resource group that in-cluster
+                volumes use.
               type: string
             caBundle:
+              description: If the migcluster needs SSL verification for connections
+                a user can supply a custom CA bundle. This field is required only
+                when spec.Insecure is set false
               format: byte
               type: string
             exposedRegistryPath:
+              description: Stores the path of registry route when using direct migration.
               type: string
             insecure:
+              description: If set false, user will need to provide CA bundle for TLS
+                connection to the remote cluster.
               type: boolean
             isHostCluster:
+              description: Specifies if the cluster is host (where the controller
+                is installed) or not. This is a required field.
               type: boolean
             refresh:
+              description: If set True, forces the controller to run a full suite
+                of validations on migcluster.
               type: boolean
             restartRestic:
+              description: An override setting to tell the controller that the source
+                cluster restic needs to be restarted after stage pod creation.
               type: boolean
             serviceAccountSecretRef:
               description: ObjectReference contains enough information to let you
@@ -99,6 +114,8 @@ spec:
                   type: string
               type: object
             url:
+              description: Stores the url of the remote cluster. The field is only
+                required for the source cluster object.
               type: string
           required:
           - isHostCluster
@@ -138,6 +155,8 @@ spec:
                 type: object
               type: array
             observedDigest:
+              type: string
+            operatorVersion:
               type: string
             registryPath:
               type: string

--- a/roles/migrationcontroller/files/migration.openshift.io_migclusters.yaml
+++ b/roles/migrationcontroller/files/migration.openshift.io_migclusters.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
@@ -26,6 +25,7 @@ spec:
     listKind: MigClusterList
     plural: migclusters
     singular: migcluster
+  preserveUnknownFields: false
   scope: Namespaced
   subresources: {}
   validation:
@@ -48,19 +48,33 @@ spec:
           description: MigClusterSpec defines the desired state of MigCluster
           properties:
             azureResourceGroup:
+              description: For azure clusters -- it's the resource group that in-cluster
+                volumes use.
               type: string
             caBundle:
+              description: If the migcluster needs SSL verification for connections
+                a user can supply a custom CA bundle. This field is required only
+                when spec.Insecure is set false
               format: byte
               type: string
             exposedRegistryPath:
+              description: Stores the path of registry route when using direct migration.
               type: string
             insecure:
+              description: If set false, user will need to provide CA bundle for TLS
+                connection to the remote cluster.
               type: boolean
             isHostCluster:
+              description: Specifies if the cluster is host (where the controller
+                is installed) or not. This is a required field.
               type: boolean
             refresh:
+              description: If set True, forces the controller to run a full suite
+                of validations on migcluster.
               type: boolean
             restartRestic:
+              description: An override setting to tell the controller that the source
+                cluster restic needs to be restarted after stage pod creation.
               type: boolean
             serviceAccountSecretRef:
               description: ObjectReference contains enough information to let you
@@ -100,6 +114,8 @@ spec:
                   type: string
               type: object
             url:
+              description: Stores the url of the remote cluster. The field is only
+                required for the source cluster object.
               type: string
           required:
           - isHostCluster
@@ -139,6 +155,8 @@ spec:
                 type: object
               type: array
             observedDigest:
+              type: string
+            operatorVersion:
               type: string
             registryPath:
               type: string


### PR DESCRIPTION
* Update MigCluster CRDs to include OperatorVersion status field

* Remove leading --- so OLM doesn't break

(cherry picked from commit 5b7782753f83d20ea482feb579a14d060ffe036d)


**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
