### PR TITLE
add docker login to stop test failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ language: python
 install:
   - pip install docker 'molecule==3.0.5' 'kubernetes==11.0.0' openshift jmespath
 script:
+  - docker login -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}"
   - molecule test -s test-local


### PR DESCRIPTION
**Description**
Fix docker rate limiting on tests.

**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
