### PR TITLE
Force overwrite of migration cluster configmap so OPERATOR_VERSION will disappear on downgrade

### DIFF
--- a/roles/migrationcontroller/tasks/main.yml
+++ b/roles/migrationcontroller/tasks/main.yml
@@ -519,6 +519,7 @@
       k8s:
         state: present
         definition: "{{ lookup('template', 'controller_config.yml.j2') }}"
+        force: yes
 
     - name: "Get mig controller configmap for hashing"
       set_fact:


### PR DESCRIPTION
**Description**
@sergiordlr reported an issue with mig-operator version not showing correct in mig-ui after downgrade to 1.3.2. This is because the configmap isn't overwritten, and keys aren't removed so the new `OPERATOR_VERSION: 1.4.2` key will remain.

This would also need to be backported to 1.3.3 (if such a thing will ever be released)

A potentially better fix here would be to go back and add the `OPERATOR_VERSION` key to older versions  so that you'd see their version instead of a "" version in the UI but this downgrade situation seems like an uncommon occurrence to me, I don't know that it's worth it. 
