### PR TITLE
(Cherry-pick) removed required field which caused breakage in upgrade (#608)

### DIFF
--- a/deploy/olm-catalog/bundle/manifests/migration.openshift.io_migplans.yaml
+++ b/deploy/olm-catalog/bundle/manifests/migration.openshift.io_migplans.yaml
@@ -279,7 +279,6 @@ spec:
                     - copyMethods
                     type: object
                 required:
-                - capacityConfirmed
                 - selection
                 - supported
                 type: object

--- a/roles/migrationcontroller/files/migration.openshift.io_migplans.yaml
+++ b/roles/migrationcontroller/files/migration.openshift.io_migplans.yaml
@@ -280,7 +280,6 @@ spec:
                     - copyMethods
                     type: object
                 required:
-                - capacityConfirmed
                 - selection
                 - supported
                 type: object


### PR DESCRIPTION
**Description**


**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
