### PR TITLE
restricting privileges for rsync-anyuid scc

### DIFF
--- a/roles/migrationcontroller/templates/custom-rsync-anyuid.yml.j2
+++ b/roles/migrationcontroller/templates/custom-rsync-anyuid.yml.j2
@@ -24,6 +24,7 @@ metadata:
 readOnlyRootFilesystem: false
 requiredDropCapabilities:
 - MKNOD
+- SETPCAP
 runAsUser:
   type: RunAsAny
 seLinuxContext:


### PR DESCRIPTION
Changing `rsync-anyuid` to restrict the scc privileges.

Counter-part PR for controller changes [konveyor/mig-controller#1001](https://github.com/konveyor/mig-controller/pull/1001)
