### PR TITLE
Add common label to Pods deployed by mig-operator

### DIFF
--- a/roles/migrationcontroller/templates/controller.yml.j2
+++ b/roles/migrationcontroller/templates/controller.yml.j2
@@ -25,6 +25,7 @@ metadata:
     app: migration
     control-plane: controller-manager
     controller-tools.k8s.io: "1.0"
+    app.kubernetes.io/part-of: openshift-migration
   name: migration-controller
   namespace: {{ mig_namespace }}
 spec:
@@ -32,6 +33,7 @@ spec:
     matchLabels:
       app: migration
       control-plane: controller-manager
+      app.kubernetes.io/part-of: openshift-migration
       controller-tools.k8s.io: "1.0"
   serviceName: controller-manager-service
   template:
@@ -39,6 +41,7 @@ spec:
       labels:
         app: migration
         control-plane: controller-manager
+        app.kubernetes.io/part-of: openshift-migration
         controller-tools.k8s.io: "1.0"
         controller_config_name: {{ controller_config_configmap.env | k8s_config_resource_name }}
         cluster_config_name: {{ cluster_config_configmap.env | k8s_config_resource_name }}

--- a/roles/migrationcontroller/templates/controller.yml.j2
+++ b/roles/migrationcontroller/templates/controller.yml.j2
@@ -33,7 +33,6 @@ spec:
     matchLabels:
       app: migration
       control-plane: controller-manager
-      app.kubernetes.io/part-of: openshift-migration
       controller-tools.k8s.io: "1.0"
   serviceName: controller-manager-service
   template:

--- a/roles/migrationcontroller/templates/discovery.yml.j2
+++ b/roles/migrationcontroller/templates/discovery.yml.j2
@@ -5,6 +5,7 @@ metadata:
   labels:
     control-plane: controller-manager
     controller-tools.k8s.io: "1.0"
+    app.kubernetes.io/part-of: openshift-migration
   name: discovery
   namespace: {{ mig_namespace }}
 spec:

--- a/roles/migrationcontroller/templates/log_reader.yml.j2
+++ b/roles/migrationcontroller/templates/log_reader.yml.j2
@@ -10,6 +10,7 @@ metadata:
   namespace: {{ mig_namespace }}
   labels:
     app: migration
+    app.kubernetes.io/part-of: openshift-migration
 spec:
   selector:
     matchLabels:

--- a/roles/migrationcontroller/templates/ui.yml.j2
+++ b/roles/migrationcontroller/templates/ui.yml.j2
@@ -39,6 +39,7 @@ spec:
       labels:
         app: migration
         service: migration-ui
+        app.kubernetes.io/part-of: openshift-migration
 {% if ui_config_configmap is defined %}
         ui-config-name: {{ ui_config_configmap.env | k8s_config_resource_name }}
 {% endif %}

--- a/roles/migrationcontroller/templates/velero.yml.j2
+++ b/roles/migrationcontroller/templates/velero.yml.j2
@@ -17,6 +17,7 @@ spec:
     metadata:
       labels:
         component: velero
+        app.kubernetes.io/part-of: openshift-migration
         restic-restore-action-config-name: {{ restic_restore_action_config_configmap.env | k8s_config_resource_name }}
       annotations:
 {% if lookup('k8s', cluster_info='version').kubernetes.minor|replace('+', '')|int < 9 %}


### PR DESCRIPTION
**Description**
This is related to https://github.com/konveyor/mig-log-reader/issues/3 . We need 1 label shared by all Pods we want to tail logs for.

@jmontleon question for you: if I change the labels on a Pod template within a deployment, do I also need to change the labelselector for the Deployment? I'm not sure of the relationship there. Hoping you can help me avoid breaking something :) 

Merge at same time with
- https://github.com/konveyor/mig-controller/pull/1003
- https://github.com/konveyor/mig-operator/pull/613
- https://github.com/konveyor/mig-log-reader/pull/8

**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [x] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role
