### PR TITLE
add no_proxy variable support to UI

### DIFF
--- a/roles/migrationcontroller/templates/ui.yml.j2
+++ b/roles/migrationcontroller/templates/ui.yml.j2
@@ -45,10 +45,14 @@ spec:
     spec:
       containers:
         - name: mig-ui
-{% if http_proxy|length >0 or https_proxy|length >0 %}
+{% if http_proxy|length >0 or https_proxy|length >0 or no_proxy|length > 0 %}
           env:
 {% else %}
           env: null
+{% endif %}
+{% if no_proxy|length >0 %}
+          - name: NO_PROXY
+            value: {{ no_proxy }}
 {% endif %}
 {% if http_proxy|length >0 %}
           - name: HTTP_PROXY


### PR DESCRIPTION
**Description**
adds no_proxy env var to UI. Related UI PR: https://github.com/konveyor/mig-ui/pull/1142
This piggybacks on to this PR that added env vars to the UI for http_proxy settings. https://github.com/konveyor/mig-operator/pull/579

**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/konveyor-operator`
* [ ] I updated channels in the `konveyor-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
