### PR TITLE
fix operator package name in annotations

### DIFF
--- a/build/Dockerfile.bundle
+++ b/build/Dockerfile.bundle
@@ -3,7 +3,7 @@ FROM scratch
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
-LABEL operators.operatorframework.io.bundle.package.v1=mtc-operator
+LABEL operators.operatorframework.io.bundle.package.v1=crane-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=release-v1.4
 LABEL operators.operatorframework.io.bundle.channel.default.v1=release-v1.4
 LABEL operators.operatorframework.io.metrics.builder=operator-sdk-unknown

--- a/deploy/build-push-subscribe.sh
+++ b/deploy/build-push-subscribe.sh
@@ -120,7 +120,7 @@ metadata:
 spec:
   channel: development
   installPlanApproval: Automatic
-  name: mtc-operator
+  name: crane-operator
   source: migration-operator
   sourceNamespace: openshift-marketplace
 EOF

--- a/deploy/downstream-prep.sh
+++ b/deploy/downstream-prep.sh
@@ -79,6 +79,8 @@ for i in ${IMAGES[@]}; do
   fi
 done
 
+sed -i 's,crane-operator,mtc-operator,g' deploy/olm-catalog/bundle/metadata/annotations.yaml
+
 # Make Downstream CSV Changes
 for f in deploy/olm-catalog/bundle/manifests/crane-operator.${MTCVERSION}.clusterserviceversion.yaml \
          deploy/non-olm/operator.yml

--- a/deploy/olm-catalog/bundle/metadata/annotations.yaml
+++ b/deploy/olm-catalog/bundle/metadata/annotations.yaml
@@ -4,5 +4,5 @@ annotations:
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
-  operators.operatorframework.io.bundle.package.v1: mtc-operator
+  operators.operatorframework.io.bundle.package.v1: crane-operator
 

--- a/deploy/push-dev-metadata.yml
+++ b/deploy/push-dev-metadata.yml
@@ -23,15 +23,9 @@
     register: tmp_dir
 
   - name: Extract operator metadata
-    shell: opm index export -c podman -i quay.io/konveyor/mig-operator-index:latest -o mtc-operator -f .
+    shell: opm index export -c podman -i quay.io/konveyor/mig-operator-index:latest -o crane-operator -f .
     args:
       chdir: "{{ tmp_dir.path }}"
-
-  - name: Replace operator name
-    replace:
-      path: "{{ tmp_dir.path }}/mtc-operator/package.yaml"
-      regexp: mtc-operator
-      replace: crane-operator
 
   - name: Get current version
     uri:

--- a/deploy/push-release-metadata.yml
+++ b/deploy/push-release-metadata.yml
@@ -36,15 +36,9 @@
     register: tmp_dir
 
   - name: Extract operator metadata
-    shell: opm index export -c podman -i quay.io/konveyor/mig-operator-index:latest -o mtc-operator -f .
+    shell: opm index export -c podman -i quay.io/konveyor/mig-operator-index:latest -o crane-operator -f .
     args:
       chdir: "{{ tmp_dir.path }}"
-
-  - name: Replace operator name
-    replace:
-      path: "{{ tmp_dir.path }}/mtc-operator/package.yaml"
-      regexp: mtc-operator
-      replace: crane-operator
 
   - name: Get current version
     uri:


### PR DESCRIPTION
**Description**


**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/crane-operator`
* [ ] I updated channels in the `crane-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
