### PR TITLE
Fix build-push-subscribe.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,9 @@ controller.yml
 my_var
 marketplace-secret.operatorsource.yml
 .DS_Store
+
+# files created by deploy/build-push-subscribe.sh
+mig-catalog-source.yml
+mig-operator-group.yml
+mig-operator-source.yml
+mig-operator-subscription.yml

--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,3 @@ controller.yml
 my_var
 marketplace-secret.operatorsource.yml
 .DS_Store
-
-# files created by deploy/build-push-subscribe.sh
-mig-catalog-source.yml
-mig-operator-group.yml
-mig-operator-source.yml
-mig-operator-subscription.yml

--- a/deploy/build-push-subscribe.sh
+++ b/deploy/build-push-subscribe.sh
@@ -102,12 +102,15 @@ apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   namespace: openshift-migration
+  labels:
+    opg-for: mtc
   generateName: openshift-migration-
 spec:
   targetNamespaces:
   - openshift-migration
 EOF
   
+  oc delete operatorgroup -l opg-for=mtc 
   oc create -f opg.yaml
   rm opg.yaml
 fi


### PR DESCRIPTION
**Description**
Having two operatorgroups in a namespace leads to OLM silent failure. I added a label to the operatorgroup so we can delete it later with a label selector since it uses a generateName and OLM doesn't like it if you use anything other than a generated name.

### What it looks like if you have two OperatorGroups (best case, worst case is silent failure)
![image](https://user-images.githubusercontent.com/7576968/112537972-b7dfdb00-8d85-11eb-9db4-cd54f60fcb7a.png)
