### PR TITLE
Changes to work with downstream ansible-operator:v4.7

### DIFF
--- a/deploy/downstream-prep.sh
+++ b/deploy/downstream-prep.sh
@@ -7,12 +7,9 @@ git checkout origin/$(git branch --show-current) -- .gitignore
 git checkout origin/$(git branch --show-current) -- content_sets.yml
 git checkout origin/$(git branch --show-current) -- container.yaml
 
-#deal with k8s_status change upstream/downstream
-sed -i "s,ansible_operator_meta,meta,g" roles/migrationcontroller/tasks/main.yml
-sed -i "s,ansible_operator_meta,meta,g" roles/migrationcontroller/templates/migration-controller.yml.j2
 
 #Fix differing entrypoint
-sed -i 's,.tini.*,exec ${OPERATOR} exec-entrypoint ansible --watches-file=/opt/ansible/watches.yaml $@,g' build/entrypoint
+sed -i 's,tini,usr/bin/tini,g' build/entrypoint
 
 #Declare image information
 IMAGES=(


### PR DESCRIPTION
This may not be the 'proper' fix, but this captures the changes I saw so our current code can work with 'registry.redhat.io/openshift4/ose-ansible-operator:v4.7'

The summary of changes are:

- We don't need to do the ansible_operator_meta/meta swap, v4.7 doesn't require it.
- '/tini' in our entrypoint needs to be updated to '/usr/bin/tini'

My test is not perfect, I just took the upstream code and built it with: "registry.redhat.io/openshift4/ose-ansible-operator:v4.7" and then tested the operator, I saw it was in a crash loop, so investigated and saw tini moved, I updated the entrypoint to '/usr/bin/tini' and rebuilt operator and saw success of basic operator workflows working on our CR and deploying our components.


