### PR TITLE
fix filenames and use oc instead of docker to get SHAs

### DIFF
--- a/crane-catalogsource.yaml
+++ b/crane-catalogsource.yaml
@@ -1,7 +1,7 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
-  name: crane-for-containers-bundle
+  name: crane
   namespace: openshift-marketplace
 spec:
   sourceType: grpc

--- a/crane-operatorsource.yaml
+++ b/crane-operatorsource.yaml
@@ -1,7 +1,7 @@
 apiVersion: operators.coreos.com/v1
 kind: OperatorSource
 metadata:
-  name: migration-operator
+  name: crane
   namespace: openshift-marketplace
 spec:
   type: appregistry

--- a/create-crane-catalogsource.sh
+++ b/create-crane-catalogsource.sh
@@ -5,6 +5,6 @@
 # The image will not get repulled even if the CatalogSource is recreated
 # So we'll pull latest, get the sha, and use that instead
 
-export BUNDLEDIGEST=$(docker pull quay.io/konveyor/mig-operator-index:latest | grep Digest | awk '{ print $2 }')
+export BUNDLEDIGEST=$(oc image mirror --dry-run=true quay.io/konveyor/mig-operator-index:latest=quay.io/konveyor/mig-operator-index:dry 2>&1 | grep -A1 manifests | grep sha256 | awk -F' ' '{ print $1 }')
 
-sed "s/:latest/@$BUNDLEDIGEST/" mig-operator-bundle.yaml | oc create -f -
+sed "s/:latest/@$BUNDLEDIGEST/" crane-catalogsource.yaml | oc create -f -

--- a/deploy/build-push-subscribe.sh
+++ b/deploy/build-push-subscribe.sh
@@ -86,7 +86,7 @@ spec:
   image: quay.io/$ORG/mig-operator-index:$TAG
 EOF
 
-  export BUNDLEDIGEST=$(docker pull quay.io/$ORG/mig-operator-index:$TAG | grep Digest | awk '{ print $2 }')
+  export BUNDLEDIGEST=$(oc image mirror --dry-run=true quay.io/$ORG/mig-operator-index:$TAG=quay.io/$ORG/mig-operator-index:dry 2>&1 | grep -A1 manifests | grep sha256 | awk -F' ' '{ print $1 }')
   sed "s/:latest/@$BUNDLEDIGEST/" catalogsource.yml | oc create -f -
   rm catalogsource.yml
 fi


### PR DESCRIPTION
**Description**
- Use oc instead of docker. When using podman(-docker) the SHAs provided are incorrect. We can break the dependency on docker for devs by using oc.
- Further renaming for crane.