### PR TITLE
[MIG-627] Add configuration for pv resizing usage threshold

### DIFF
--- a/docs/usage/IntelligentPVResizing.md
+++ b/docs/usage/IntelligentPVResizing.md
@@ -46,4 +46,15 @@ MTC uses following criteria to calculate resulting PVC capacity in the target cl
 
 2. If a PV originally provisioned through a PVC is altered using ad-hoc storage utilities (e.g. Gluster CLI) making capacities in PVC and the PV mismatch, maximum of both capacities is used as resulting capacity.  
 
-3. If disk usage of the volume is more than 97%, an extra headroom of 3% is added to the original usage percentage.
+3. If disk usage of the volume is more than 97%, an extra headroom of 3% is added to the original usage percentage. This threshold can be adjusted in _MigrationController_ CR using `pv_resizing_threshold` variable:
+
+```yaml
+apiVersion: migration.openshift.io/v1alpha1
+kind: MigrationController
+metadata:
+  name: migration-controller
+  namespace: openshift-migration
+spec:
+  [...]
+  pv_resizing_threshold: 3
+```

--- a/roles/migrationcontroller/templates/controller_config.yml.j2
+++ b/roles/migrationcontroller/templates/controller_config.yml.j2
@@ -58,4 +58,6 @@ data:
   DISABLE_IMAGE_COPY: "{{ disable_image_copy }}"
 {% endif %}
   JAEGER_ENABLED: "{{ jaeger_enabled }}"
-
+{% if pv_resizing_threshold is defined %}
+  PV_RESIZING_USAGE_THRESHOLD: "{{ pv_resizing_threshold }}"
+{% endif %}


### PR DESCRIPTION
**Description**

This PR adds a new configuration variable to specify a custom threshold value for PV resizing
**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/crane-operator`
* [ ] I updated channels in the `crane-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
