### PR TITLE
Adding ability to handle difference between ansible operator base image

### DIFF
--- a/build/entrypoint
+++ b/build/entrypoint
@@ -17,4 +17,8 @@ if [ x"$USER_ID" != x"0" -a x"$USER_ID" != x"1001" ]; then
     export LD_PRELOAD
 fi
 
-/tini -- /usr/local/bin/ansible-operator run --watches-file=./watches.yaml
+if [ -f "/tini" ]; then
+        /tini -- /usr/local/bin/ansible-operator run --watches-file=./watches.yaml
+else
+        /usr/bin/tini -- /usr/local/bin/ansible-operator run --watches-file=./watches.yaml
+fi

--- a/deploy/downstream-prep.sh
+++ b/deploy/downstream-prep.sh
@@ -8,9 +8,6 @@ git checkout origin/$(git branch --show-current) -- content_sets.yml
 git checkout origin/$(git branch --show-current) -- container.yaml
 
 
-#Fix differing entrypoint
-sed -i 's,tini,usr/bin/tini,g' build/entrypoint
-
 #Declare image information
 IMAGES=(
   "controller"


### PR DESCRIPTION
**Description**
Add ability for entrypoint to handle diff between RPM installed `tini` and root installed `tini`

**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/crane-operator`
* [ ] I updated channels in the `crane-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
