### PR TITLE
Add render_templates coverage in ds-prep (#629)

### DIFF
--- a/deploy/downstream-prep.sh
+++ b/deploy/downstream-prep.sh
@@ -6,6 +6,9 @@ git checkout origin/$(git branch --show-current) -- Dockerfile
 git checkout origin/$(git branch --show-current) -- .gitignore
 git checkout origin/$(git branch --show-current) -- content_sets.yml
 git checkout origin/$(git branch --show-current) -- container.yaml
+for file in $(git status --porcelain -- render_templates* | awk '{print $2}'); do
+  git checkout origin/$(git branch --show-current) -- "${file}"
+done
 
 
 #Declare image information


### PR DESCRIPTION
**Description**

Bring `release-1.4.3`'s https://github.com/konveyor/mig-operator/pull/629 into `master` to support render_templates use in downstream going forward.

