### PR TITLE
Bug 1934877: Add registry timeout configuration variable

### DIFF
--- a/docs/usage/MigClusterConfiguration.md
+++ b/docs/usage/MigClusterConfiguration.md
@@ -1,0 +1,19 @@
+# MigCluster Configuration
+
+For every _MigCluster_ resource created in MTC, a _ConfigMap_ named `migration-cluster-config` is created in Migration Operator's namespace on the cluster which _MigCluster_ resource represents. It allows configuring _MigCluster_ specific values and is managed by the Migration Operator. Every value in the _ConfigMap_ can be configured using the variables exposed in _MigrationController_ CR.
+
+## Usage
+
+Following table summarizes the _MigrationController_ variables:
+
+| Variable                             	| Type   	| Required 	| Description                                                              	|
+|--------------------------------------	|--------	|----------	|--------------------------------------------------------------------------	|
+| migration_stage_image_fqin           	| string 	| No       	| Image to use for Stage Pods (only applicable to IndirectVolumeMigration) 	|
+| migration_registry_image_fqin        	| string 	| No       	| Image to use for Migration Registry                                      	|
+| rsync_transfer_image_fqin            	| string 	| No       	| Image to use for Rsync Pods (only applicable to DirectVolumeMigration)   	|
+| migration_rsync_privileged           	| bool   	| No       	| Whether to run Rsync Pods as privileged or not                           	|
+| cluster_subdomain                    	| string 	| No       	| Cluster's subdomain                                                      	|
+| migration_registry_readiness_timeout 	| int    	| No       	| Readiness timeout (in seconds) for Migration Registry Deployment         	|
+| migration_registry_liveness_timeout  	| int    	| No       	| Liveness timeout (in seconds) for Migration Registry Deployment          	|
+
+> Note that the values are specific to MigCluster resource. Therefore, the variables need to be updated in the MigrationController resource present on the respective cluster you wish to update. The values that are *not required* will be automatically set by the Migration Operator or the Migration Controller.

--- a/docs/usage/README.md
+++ b/docs/usage/README.md
@@ -26,3 +26,4 @@ installing CAM for OCP3->3 installations, and 4->4 installations.<br>
 [Section 19 - Intelligent PV resizing](./IntelligentPVResizing.md)<br>
 [Section 20 - MTC with Kubernetes Controller-Runtime Package](./MTCControllerRuntime.md)<br>
 [Section 21 - Proxy configuration for Direct Volume Migration](./DVMProxyConfiguration.md)<br>
+[Section 22 - Adjusting MigCluster ConfigMap](./MigClusterConfiguration.md)<br>

--- a/roles/migrationcontroller/templates/mig-cluster-config.yml.j2
+++ b/roles/migrationcontroller/templates/mig-cluster-config.yml.j2
@@ -14,3 +14,10 @@ data:
   RSYNC_PRIVILEGED: "{{ migration_rsync_privileged }}"
   CLUSTER_SUBDOMAIN: "{{ cluster_subdomain }}"
   OPERATOR_VERSION: "{{ mig_operator_version }}"
+{% if migration_registry_readiness_timeout is defined %}
+  REGISTRY_READINESS_TIMEOUT: "{{ migration_registry_readiness_timeout }}"
+{% endif %}
+{% if migration_registry_liveness_timeout is defined %}
+  REGISTRY_LIVENESS_TIMEOUT: "{{ migration_registry_liveness_timeout }}"
+{% endif %}
+


### PR DESCRIPTION
**Description**


**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/crane-operator`
* [ ] I updated channels in the `crane-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
