### PR TITLE
 Adding ability to handle difference between ansible operator base image #650

### DIFF
--- a/build/entrypoint
+++ b/build/entrypoint
@@ -17,4 +17,8 @@ if [ x"$USER_ID" != x"0" -a x"$USER_ID" != x"1001" ]; then
     export LD_PRELOAD
 fi
 
-/tini -- /usr/local/bin/ansible-operator run --watches-file=./watches.yaml
+if [ -f "/tini" ]; then
+        /tini -- /usr/local/bin/ansible-operator run --watches-file=./watches.yaml
+else
+        /usr/bin/tini -- /usr/local/bin/ansible-operator run --watches-file=./watches.yaml
+fi

--- a/deploy/downstream-prep.sh
+++ b/deploy/downstream-prep.sh
@@ -11,9 +11,6 @@ for file in $(git status --porcelain -- render_templates* | awk '{print $2}'); d
 done
 
 
-#Fix differing entrypoint
-sed -i 's,tini,usr/bin/tini,g' build/entrypoint
-
 #Declare image information
 IMAGES=(
   "controller"


### PR DESCRIPTION
Pull in changes from https://github.com/konveyor/mig-operator/pull/650

We're missing this enhancement in 1.4.4 because `release-1.4.4` was cut from 1.4.3 instead of master this time around.