### PR TITLE
Revert "(temporarily) pin community.kubernetes to fix operator_sdk.util (#475)

### DIFF
--- a/build/requirements.yml
+++ b/build/requirements.yml
@@ -1,4 +1,3 @@
 collections:
-  - name: community.kubernetes
-    version: <=1.0
-  - name: operator_sdk.util
+  - community.kubernetes
+  - operator_sdk.util


### PR DESCRIPTION
This reverts commit 190b464d427e49f1108cc27204418604e32ed1dd.

**Description**
Remove version pinning which surfaced in PRs ([example](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/konveyor_mig-operator/669/pull-ci-konveyor-mig-operator-master-ci-index/1392139809291505664)) as:
**Cannot meet requirement community.kubernetes:<=1.0 as it is already installed at version '1.2.1'. Use --force to overwrite** 
```
STEP 14: RUN ansible-galaxy collection install -r ${HOME}/requirements.yml  && chmod -R ug+rwx ${HOME}/.ansible
time="2021-05-11T15:37:15Z" level=warning msg="Path \"/run/secrets/etc-pki-entitlement\" from \"/etc/containers/mounts.conf\" doesn't exist, skipping"
time="2021-05-11T15:37:15Z" level=warning msg="Path \"/run/secrets/redhat.repo\" from \"/etc/containers/mounts.conf\" doesn't exist, skipping"
Process install dependency map
|/-ERROR! Cannot meet requirement community.kubernetes:<=1.0 as it is already installed at version '1.2.1'. Use --force to overwrite 
```


