### PR TITLE
Bug 1981537: Remove additionalProperties validation from DVMP CRD (#711)

### DIFF
--- a/deploy/olm-catalog/bundle/manifests/migration.openshift.io_directvolumemigrationprogresses.yaml
+++ b/deploy/olm-catalog/bundle/manifests/migration.openshift.io_directvolumemigrationprogresses.yaml
@@ -133,8 +133,6 @@ spec:
                   type: string
               type: object
             podSelector:
-              additionalProperties:
-                type: string
               type: object
           type: object
         status:

--- a/roles/migrationcontroller/files/migration.openshift.io_directvolumemigrationprogresses.yaml
+++ b/roles/migrationcontroller/files/migration.openshift.io_directvolumemigrationprogresses.yaml
@@ -134,8 +134,6 @@ spec:
                   type: string
               type: object
             podSelector:
-              additionalProperties:
-                type: string
               type: object
           type: object
         status:


### PR DESCRIPTION
* remove additionalProperties and validation from DVMP crd

* update OLM manifest for DVMP

**Description**
(Cherry-picked from 59f0862)

**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/crane-operator`
* [ ] I updated channels in the `crane-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
