### PR TITLE
Updates for 1.5.2

### DIFF
--- a/deploy/non-olm/operator.yml
+++ b/deploy/non-olm/operator.yml
@@ -288,7 +288,7 @@ spec:
       serviceAccountName: migration-operator
       containers:
       - name: operator
-        image: quay.io/konveyor/mig-operator-container:release-1.5.1
+        image: quay.io/konveyor/mig-operator-container:release-1.5.2
         imagePullPolicy: Always
         volumeMounts:
         - mountPath: /tmp/ansible-operator/runner
@@ -311,11 +311,11 @@ spec:
         - name: RSYNC_TRANSFER_REPO
           value: rsync-transfer
         - name: RSYNC_TRANSFER_TAG
-          value: release-1.5.1
+          value: release-1.5.2
         - name: HOOK_RUNNER_REPO
           value: hook-runner
         - name: HOOK_RUNNER_TAG
-          value: release-1.5.1
+          value: release-1.5.2
         - name: MIG_CONTROLLER_REPO
           value: mig-controller
         - name: MIG_UI_REPO
@@ -325,7 +325,7 @@ spec:
         - name: MIGRATION_REGISTRY_REPO
           value: registry
         - name: MIGRATION_REGISTRY_TAG
-          value: release-1.5.1
+          value: release-1.5.2
         - name: VELERO_REPO
           value: velero
         - name: VELERO_PLUGIN_REPO
@@ -339,23 +339,23 @@ spec:
         - name: VELERO_AZURE_PLUGIN_REPO
           value: velero-plugin-for-microsoft-azure
         - name: VELERO_TAG
-          value: release-1.5.1
+          value: release-1.5.2
         - name: VELERO_RESTIC_RESTORE_HELPER_TAG
-          value: release-1.5.1
+          value: release-1.5.2
         - name: VELERO_PLUGIN_TAG
-          value: release-1.5.1
+          value: release-1.5.2
         - name: VELERO_AWS_PLUGIN_TAG
-          value: release-1.5.1
+          value: release-1.5.2
         - name: VELERO_GCP_PLUGIN_TAG
-          value: release-1.5.1
+          value: release-1.5.2
         - name: VELERO_AZURE_PLUGIN_TAG
-          value: release-1.5.1
+          value: release-1.5.2
         - name: MIG_UI_TAG
-          value: release-1.5.1
+          value: release-1.5.2
         - name: MIG_CONTROLLER_TAG
-          value: release-1.5.1
+          value: release-1.5.2
         - name: MIG_LOG_READER_TAG
-          value: release-1.5.1
+          value: release-1.5.2
       volumes:
         - name: runner
           emptyDir: {}

--- a/deploy/olm-catalog/bundle/manifests/crane-operator.v1.5.2.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/bundle/manifests/crane-operator.v1.5.2.clusterserviceversion.yaml
@@ -2,15 +2,15 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: crane-operator.v1.5.1
+  name: crane-operator.v1.5.2
   namespace: openshift-migration
   annotations:
     olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.8"}]'
-    olm.skipRange: '>=0.0.0 <1.5.1'
+    olm.skipRange: '>=0.0.0 <1.5.2'
     capabilities: Seamless Upgrades
     description: Facilitates migration of container workloads from OpenShift 3.x to OpenShift 4.x
-    categories: 'OpenShift Optional'
-    containerImage: quay.io/konveyor/mig-operator-container:release-1.5.1
+    categories: 'Modernization & Migration, OpenShift Optional'
+    containerImage: quay.io/konveyor/mig-operator-container:release-1.5.2
     createdAt: 2019-07-25T10:21:00Z
     repository: https://github.com/konveyor/mig-operator
     alm-examples: |-
@@ -230,6 +230,7 @@ metadata:
     operatorframework.io/suggested-namespace: openshift-migration
 spec:
   skips:
+  - crane-operator.v1.5.1
   - crane-operator.v1.5.0
   - crane-operator.v1.4.7
   - crane-operator.v1.4.6
@@ -250,29 +251,29 @@ spec:
   - crane-operator.v1.2.0
   relatedImages:
   - name: controller
-    image: quay.io/konveyor/mig-controller:release-1.5.1
+    image: quay.io/konveyor/mig-controller:release-1.5.2
   - name: ui
-    image: quay.io/konveyor/mig-ui:release-1.5.1
+    image: quay.io/konveyor/mig-ui:release-1.5.2
   - name: velero
-    image: quay.io/konveyor/velero:release-1.5.1
+    image: quay.io/konveyor/velero:release-1.5.2
   - name: velero_restic_restore_helper
-    image: quay.io/konveyor/velero-restic-restore-helper:release-1.5.1
+    image: quay.io/konveyor/velero-restic-restore-helper:release-1.5.2
   - name: migration_plugin
-    image: quay.io/konveyor/openshift-velero-plugin:release-1.5.1
+    image: quay.io/konveyor/openshift-velero-plugin:release-1.5.2
   - name: aws_plugin
-    image: quay.io/konveyor/velero-plugin-for-aws:release-1.5.1
+    image: quay.io/konveyor/velero-plugin-for-aws:release-1.5.2
   - name: azure_plugin
-    image: quay.io/konveyor/velero-plugin-for-microsoft-azure:release-1.5.1
+    image: quay.io/konveyor/velero-plugin-for-microsoft-azure:release-1.5.2
   - name: gcp_plugin
-    image: quay.io/konveyor/velero-plugin-for-gcp:release-1.5.1
+    image: quay.io/konveyor/velero-plugin-for-gcp:release-1.5.2
   - name: registry
-    image: quay.io/konveyor/registry:release-1.5.1
+    image: quay.io/konveyor/registry:release-1.5.2
   - name: hook_runner
-    image: quay.io/konveyor/hook-runner:release-1.5.1
+    image: quay.io/konveyor/hook-runner:release-1.5.2
   - name: mig_log_reader
-    image: quay.io/konveyor/mig-log-reader:release-1.5.1
+    image: quay.io/konveyor/mig-log-reader:release-1.5.2
   - name: rsync_transfer
-    image: quay.io/konveyor/rsync-transfer:release-1.5.1
+    image: quay.io/konveyor/rsync-transfer:release-1.5.2
   displayName: Crane Operator
   description: |
     The Crane Operator enables installation of the application migration tool components.
@@ -306,7 +307,7 @@ spec:
     url: https://github.com/konveyor/mig-operator
 
   labels:
-    alm-status-descriptors: crane-operator.v1.5.1
+    alm-status-descriptors: crane-operator.v1.5.2
     alm-owner-prometheus: crane-operator
 
   selector:
@@ -799,7 +800,7 @@ spec:
               serviceAccount: migration-operator
               containers:
               - name: operator
-                image: quay.io/konveyor/mig-operator-container:release-1.5.1
+                image: quay.io/konveyor/mig-operator-container:release-1.5.2
                 imagePullPolicy: Always
                 volumeMounts:
                 - mountPath: /tmp/ansible-operator/runner
@@ -822,56 +823,56 @@ spec:
                 - name: RSYNC_TRANSFER_REPO
                   value: rsync-transfer
                 - name: RSYNC_TRANSFER_TAG
-                  value: release-1.5.1
+                  value: release-1.5.2
                 - name: HOOK_RUNNER_REPO
                   value: hook-runner
                 - name: HOOK_RUNNER_TAG
-                  value: release-1.5.1
+                  value: release-1.5.2
                 - name: MIG_CONTROLLER_REPO
                   value: mig-controller
                 - name: MIG_CONTROLLER_TAG
-                  value: release-1.5.1
+                  value: release-1.5.2
                 - name: MIG_UI_REPO
                   value: mig-ui
                 - name: MIG_UI_TAG
-                  value: release-1.5.1
+                  value: release-1.5.2
                 - name: MIG_LOG_READER_REPO
                   value: mig-log-reader
                 - name: MIG_LOG_READER_TAG
-                  value: release-1.5.1
+                  value: release-1.5.2
                 - name: MIGRATION_REGISTRY_REPO
                   value: registry
                 - name: MIGRATION_REGISTRY_TAG
-                  value: release-1.5.1
+                  value: release-1.5.2
                 - name: VELERO_REPO
                   value: velero
                 - name: VELERO_TAG
-                  value: release-1.5.1
+                  value: release-1.5.2
                 - name: VELERO_PLUGIN_REPO
                   value: openshift-velero-plugin
                 - name: VELERO_PLUGIN_TAG
-                  value: release-1.5.1
+                  value: release-1.5.2
                 - name: VELERO_AWS_PLUGIN_REPO
                   value: velero-plugin-for-aws
                 - name: VELERO_AWS_PLUGIN_TAG
-                  value: release-1.5.1
+                  value: release-1.5.2
                 - name: VELERO_GCP_PLUGIN_REPO
                   value: velero-plugin-for-gcp
                 - name: VELERO_GCP_PLUGIN_TAG
-                  value: release-1.5.1
+                  value: release-1.5.2
                 - name: VELERO_AZURE_PLUGIN_REPO
                   value: velero-plugin-for-microsoft-azure
                 - name: VELERO_AZURE_PLUGIN_TAG
-                  value: release-1.5.1
+                  value: release-1.5.2
                 - name: VELERO_RESTIC_RESTORE_HELPER_REPO
                   value: velero-restic-restore-helper
                 - name: VELERO_RESTIC_RESTORE_HELPER_TAG
-                  value: release-1.5.1
+                  value: release-1.5.2
               volumes:
               - name: runner
                 emptyDir: {}
   maturity: alpha
-  version: 1.5.1
+  version: 1.5.2
   customresourcedefinitions:
     owned:
     - name: backupstoragelocations.velero.io

--- a/molecule/deploy/operator.yaml
+++ b/molecule/deploy/operator.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: migration-operator
       containers:
       - name: operator
-        image: quay.io/konveyor/mig-operator-container:release-1.5.1
+        image: quay.io/konveyor/mig-operator-container:release-1.5.2
         imagePullPolicy: Always
         volumeMounts:
         - mountPath: /tmp/ansible-operator/runner
@@ -40,7 +40,7 @@ spec:
         - name: HOOK_RUNNER_REPO
           value: hook-runner
         - name: HOOK_RUNNER_TAG
-          value: release-1.5.1
+          value: release-1.5.2
         - name: MIG_CONTROLLER_REPO
           value: mig-controller
         - name: MIG_UI_REPO
@@ -48,7 +48,7 @@ spec:
         - name: MIGRATION_REGISTRY_REPO
           value: registry
         - name: MIGRATION_REGISTRY_TAG
-          value: release-1.5.1
+          value: release-1.5.2
         - name: VELERO_REPO
           value: velero
         - name: VELERO_PLUGIN_REPO
@@ -62,21 +62,21 @@ spec:
         - name: VELERO_AZURE_PLUGIN_REPO
           value: velero-plugin-for-microsoft-azure
         - name: VELERO_TAG
-          value: release-1.5.1
+          value: release-1.5.2
         - name: VELERO_RESTIC_RESTORE_HELPER_TAG
-          value: release-1.5.1
+          value: release-1.5.2
         - name: VELERO_PLUGIN_TAG
-          value: release-1.5.1
+          value: release-1.5.2
         - name: VELERO_AWS_PLUGIN_TAG
-          value: release-1.5.1
+          value: release-1.5.2
         - name: VELERO_GCP_PLUGIN_TAG
-          value: release-1.5.1
+          value: release-1.5.2
         - name: VELERO_AZURE_PLUGIN_TAG
-          value: release-1.5.1
+          value: release-1.5.2
         - name: MIG_UI_TAG
-          value: release-1.5.1
+          value: release-1.5.2
         - name: MIG_CONTROLLER_TAG
-          value: release-1.5.1
+          value: release-1.5.2
       volumes:
         - name: runner
           emptyDir: {}

--- a/molecule/kind/converge.yml
+++ b/molecule/kind/converge.yml
@@ -5,7 +5,7 @@
   collections:
     - community.kubernetes
   vars:
-    image: quay.io/konveyor/mig-operator-container:release-1.5.1
+    image: quay.io/konveyor/mig-operator-container:release-1.5.2
   tasks:
     # using command so we don't need to install any dependencies
     - name: Get existing image hash

--- a/molecule/kind/molecule.yml
+++ b/molecule/kind/molecule.yml
@@ -34,7 +34,7 @@ provisioner:
         migration_namespace: ${TEST_MIGRATION_NAMESPACE:-openshift-migration}
         namespace: ${TEST_OPERATOR_NAMESPACE:-openshift-migration}
         kubeconfig_file: ${MOLECULE_EPHEMERAL_DIRECTORY}/kubeconfig
-        test_image: ${REPLACE_IMAGE:-quay.io/konveyor/mig-operator-container:release-1.5.1}
+        test_image: ${REPLACE_IMAGE:-quay.io/konveyor/mig-operator-container:release-1.5.2}
     host_vars:
       localhost:
         ansible_python_interpreter: '{{ ansible_playbook_python }}'

--- a/roles/migrationcontroller/defaults/main.yml
+++ b/roles/migrationcontroller/defaults/main.yml
@@ -62,7 +62,7 @@ mig_controller_image_fqin: "{{ mig_controller_image }}:{{ mig_controller_version
 mig_controller_enable_cache: false
 discovery_collect_events: true
 discovery_volume_path: "/var/cache/discovery"
-mig_operator_version: "1.5.1"
+mig_operator_version: "1.5.2"
 mig_pv_move_storageclasses: []
 mig_pv_limit: "100"
 mig_pod_limit: "100"


### PR DESCRIPTION
In addition to the typical version string bump, this also reintroduces the '[Modernization & Migration](https://github.com/konveyor/mig-operator/blob/1c865db16572914d8c260384c0110bd791dca887/deploy/olm-catalog/bundle/manifests/crane-operator.v1.5.2.clusterserviceversion.yaml#L12)' category since we're no longer constrained by appregistry backport for MTC 1.5.