### PR TITLE
Change recommendation for 1.6.0 to use mig-operator

### DIFF
--- a/docs/usage/CompatibleOCPVersions.md
+++ b/docs/usage/CompatibleOCPVersions.md
@@ -6,7 +6,7 @@ Refer to the guidelines below to select the correct mig-operator version for you
 
  - **OpenShift 3.7 - 4.5**
    - Crane 1.5.x is compatible
-   - Install Crane using [mig-legacy-operator](https://github.com/konveyor/mig-legacy-operator) available from YAML manifests.
+   - Install Crane using [mig-operator 1.5.x](https://github.com/konveyor/mig-operator/tree/release-1.5.1) available from YAML manifests.
  - **OpenShift 4.6+**
    - Crane 1.6.x+ is compatible
    - Install Crane using [mig-operator](https://github.com/konveyor/mig-operator) available from OperatorHub.


### PR DESCRIPTION
mig-operator should be used in 1.6.0, not mig-legacy-operator.

There was previously some confusion around which operator (mig-legacy-operator vs mig-operator) would ship in 1.6.0, now that is cleared up:

This PR is meant to get the 1.6.0 docs clear of confusion so users aren't mislead.

In MTC 1.6.0:
 - OCP 3.7 - 4.5: mig-operator 1.5.x
 - OCP 4.6 - 4.9+: mig-operator 1.6.x

In MTC 1.7.0+:
 - OCP 3.7 - 4.5: mig-legacy-operator latest
 - OCP 4.6 - 4.9+: mig-operator latest