### PR TITLE
Bug 2021668: Allow mig-controller to get subdomain

### DIFF
--- a/deploy/olm-catalog/bundle/manifests/crane-operator.v99.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/bundle/manifests/crane-operator.v99.0.0.clusterserviceversion.yaml
@@ -667,6 +667,14 @@ spec:
           - privileged
           - rsync-anyuid
         - apiGroups:
+          - config.openshift.io
+          resources:
+          - ingresses
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - apps.openshift.io
           - route.openshift.io
           resources:


### PR DESCRIPTION
**Description**

In order for the mig-controller to be able to get the subdomain from the
target clusters, we need permission to acces the cluster's ingress
config object. This PR adds those permissions to the mig-controller
serviceaccount.

**Check each of the following when appropriate to help reviewers verify work is complete.**

**Modifying an existing version**
* [ ] I modified operator permissions in the OLM CSV **and** operator.yml
* [ ] I modified the operator deployment in the OLM CSV **and** operator.yml
* [ ] I modified operand permissions in the OLM CSV **and** ansible role
* [ ] I modified CRDS in the OLM CSV **and** ansible role

**Adding a new release version**
* [ ] I created a new z release directory in `deploy/olm-catalog/crane-operator`
* [ ] I updated channels in the `crane-operator.package.yaml`
* [ ] I created a new release directory in `deploy/non-olm`
* [ ] I created or updated the major.minor link in `deploy/non-olm`
* [ ] I updated the spec.skips parameter in the CSV
