### PR TITLE
Bug 2021668: Allow mig-controller to get subdomain

### DIFF
--- a/deploy/olm-catalog/bundle/manifests/crane-operator.v1.6.3.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/bundle/manifests/crane-operator.v1.6.3.clusterserviceversion.yaml
@@ -645,6 +645,14 @@ spec:
           - privileged
           - rsync-anyuid
         - apiGroups:
+          - config.openshift.io
+          resources:
+          - ingresses
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - apps.openshift.io
           - route.openshift.io
           resources:


### PR DESCRIPTION
In order for the mig-controller to be able to get the subdomain from the
target clusters, we need permission to acces the cluster's ingress
config object. This PR adds those permissions to the mig-controller
serviceaccount.