### PR TITLE
Add restic CPU/Memory resources requirements

### DIFF
--- a/roles/migrationcontroller/defaults/main.yml
+++ b/roles/migrationcontroller/defaults/main.yml
@@ -100,6 +100,7 @@ enable_intelligent_pv_resize: true
 registry: "{{ lookup( 'env', 'REGISTRY') }}"
 project: "{{ lookup( 'env', 'PROJECT') }}"
 restic_pv_host_path: /var/lib/kubelet/pods
+restic_requests_cpu: "100m"
 restic_timeout: 1h
 restic_supplemental_groups: []
 ui_state: absent

--- a/roles/migrationcontroller/templates/velero.yml.j2
+++ b/roles/migrationcontroller/templates/velero.yml.j2
@@ -16,10 +16,27 @@ spec:
       enable: true
       timeout: "{{ restic_timeout }}"
       supplementalGroups: {{ restic_supplemental_groups }}
-{% if _migration_openshift_io_migrationcontroller_spec.daemonset_node_selector is defined %}
       podConfig:
+{% if _migration_openshift_io_migrationcontroller_spec.daemonset_node_selector is defined %}
         nodeSelector: {{ _migration_openshift_io_migrationcontroller_spec.daemonset_node_selector | to_yaml }}
-{% else %}
-      podConfig: {}
+{% endif %}
+        resourceAllocations:
+{% if restic_requests_cpu is defined or restic_requests_memory is defined %}
+          requests:
+{% if restic_requests_cpu is defined %}
+            cpu: "{{ restic_requests_cpu }}"
+{% endif %}
+{% if restic_requests_memory is defined %}
+            memory: "{{ restic_requests_memory }}"
+{% endif %}
+{% endif %}
+{% if restic_limits_cpu is defined or restic_limits_memory is defined %}
+{% if restic_limits_cpu is defined %}
+          limits:
+            cpu: "{{ restic_limits_cpu }}"
+{% endif %}
+{% if restic_limits_memory is defined %}
+            memory: "{{ restic_limits_memory }}"
+{% endif %}
 {% endif %}
 


### PR DESCRIPTION
Introduces resource allocations in the Velero podConfig. Intentionally does not set any default values except the `requests.cpu` of Restic Pod. The values are set only when explicitely specified by the user