### PR TITLE
Adding privilege labels to namespace to run workloads as expected with 4.12 changes

### DIFF
--- a/deploy/olm-catalog/bundle/manifests/migration.openshift.io_migmigrations.yaml
+++ b/deploy/olm-catalog/bundle/manifests/migration.openshift.io_migmigrations.yaml
@@ -136,6 +136,22 @@ spec:
                   true the migration controller switches to rollback itinerary. This
                   field needs to be set prior to creation of a MigMigration.
                 type: boolean
+              runAsGroup:
+                description: If set, runs rsync operations with provided group id.
+                  This provided user id should be a valid one that falls within the
+                  range of allowed GID of user namespace
+                format: int64
+                type: integer
+              runAsRoot:
+                description: If set True, run rsync operations with escalated privileged,
+                  takes precedence over setting RunAsUser and RunAsGroup
+                type: boolean
+              runAsUser:
+                description: If set, runs rsync operations with provided user id.
+                  This provided user id should be a valid one that falls within the
+                  range of allowed UID of user namespace
+                format: int64
+                type: integer
               stage:
                 description: Invokes the stage operation, when set to true the migration
                   controller switches to stage itinerary. This is a required field.

--- a/roles/migrationcontroller/templates/monitoring-namespace-label.yml.j2
+++ b/roles/migrationcontroller/templates/monitoring-namespace-label.yml.j2
@@ -4,5 +4,8 @@ kind: Namespace
 metadata:
   labels:
     openshift.io/cluster-monitoring: "true"
+    pod-security.kubernetes.io/enforce: "privileged"
+    pod-security.kubernetes.io/audit: "privileged"
+    pod-security.kubernetes.io/warn: "privileged"
   name: "{{ mig_namespace }}"
   


### PR DESCRIPTION
This change adds labels to `openshift-migration` namespace

```
apiVersion: v1
kind: Namespace
metadata:
  annotations:
    openshift.io/sa.scc.mcs: s0:c28,c17
    openshift.io/sa.scc.supplemental-groups: 1000790000/10000
    openshift.io/sa.scc.uid-range: 1000790000/10000
  creationTimestamp: "2022-07-06T14:36:55Z"
  labels:
    kubernetes.io/metadata.name: openshift-migration
    olm.operatorgroup.uid/35f641da-0d72-4f3c-8198-e221d07935f1: ""
    olm.operatorgroup.uid/816f05b4-9842-4bb4-b216-d08315c4d511: ""
    openshift.io/cluster-monitoring: "true"
    pod-security.kubernetes.io/audit: privileged
    pod-security.kubernetes.io/enforce: privileged
    pod-security.kubernetes.io/warn: privileged
  name: openshift-migration
spec:
  finalizers:
  - kubernetes
status:
  phase: Active
```